### PR TITLE
Remove TensorFlow Serving from bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ KubeFlow consists of:
 
   * TensorFlow Training, for training TensorFlow models
 
-  * TensorFlow Serving, to serve trained TensorFlow models
-
   * Ambassador, an API gateway for managing access to the services
 
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -6,9 +6,6 @@ applications:
   kubeflow-tf-job-dashboard:
     charm: cs:~juju/kubeflow-tf-job-dashboard
     scale: 1
-  kubeflow-tf-serving:
-    charm: cs:~juju/kubeflow-tf-serving
-    scale: 1
   kubeflow-tf-job-operator:
     charm: cs:~juju/kubeflow-tf-job-operator
     scale: 1


### PR DESCRIPTION
TensorFlow Serving requires being passed in a model to enter the active state, and `juju-wait` will currently block until TensorFlow Serving has entered the active state. Removing TensorFlow Serving from this bundle in favor of running it independently with a model specified.