### PR TITLE
Adding service annotations for Ambassador

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,14 +1,42 @@
 bundle: kubernetes
 applications:
   kubeflow-tf-hub:
-    charm: cs:~juju/kubeflow-tf-hub
+    charm: cs:~kubeflow-charmers/kubeflow-tf-hub
     scale: 1
+    options:
+      kubernetes-service-annotations:
+        getambassador.io/config: |
+          ---
+          apiVersion: ambassador/v0
+          kind:  Mapping
+          name:  tf_hub
+          prefix: /hub/
+          rewrite: /hub/
+          service: juju-kubeflow-tf-hub:8000
+          use_websocket: true
+          ---
+          apiVersion: ambassador/v0
+          kind:  Mapping
+          name:  tf_hub_user
+          prefix: /user/
+          rewrite: /user/
+          service: juju-kubeflow-tf-hub:8000
   kubeflow-tf-job-dashboard:
-    charm: cs:~juju/kubeflow-tf-job-dashboard
+    charm: cs:~kubeflow-charmers/kubeflow-tf-job-dashboard
     scale: 1
+    options:
+      kubernetes-service-annotations:
+        getambassador.io/config: |
+          ---
+          apiVersion: ambassador/v0
+          kind:  Mapping
+          name:  job_dashboard
+          prefix: /tfjobs/
+          rewrite: /tfjobs/
+          service: juju-kubeflow-tf-job-dashboard:8080
   kubeflow-tf-job-operator:
-    charm: cs:~juju/kubeflow-tf-job-operator
+    charm: cs:~kubeflow-charmers/kubeflow-tf-job-operator
     scale: 1
   kubeflow-ambassador:
-    charm: cs:~juju/kubeflow-ambassador
+    charm: cs:~kubeflow-charmers/kubeflow-ambassador
     scale: 1


### PR DESCRIPTION
Instead of configuring Ambassador directly, we can add Annotations to each relevant Service.

Requires that we first successfully push each charm to the new `kubeflow-charmers` namespace.