### PR TITLE
Escape backtick characters in deploy-microk8s.sh

### DIFF
--- a/scripts/deploy-microk8s.sh
+++ b/scripts/deploy-microk8s.sh
@@ -34,7 +34,7 @@ AMBASSADOR_IP=$(juju status | grep "kubeflow-ambassador " | awk '{print $8}')
 cat << EOF
 
 
-Congratulations, Kubeflow is now available. Run `microk8s.kubectl proxy` to be able to access the dashboard at
+Congratulations, Kubeflow is now available. Run \`microk8s.kubectl proxy\` to be able to access the dashboard at
 
     http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/overview?namespace=$MODEL
 


### PR DESCRIPTION
Otherwise Bash interprets them as normal backticks that exec their contents.