### PR TITLE
Adding model name to juju status call

### DIFF
--- a/scripts/deploy-aws.sh
+++ b/scripts/deploy-aws.sh
@@ -51,7 +51,7 @@ juju deploy ./bundle.yaml
 juju wait -e aws-us-east-1:$MODEL -w
 
 # Expose the Ambassador reverse proxy and print out a success message
-PUB_IP=$(juju status | grep "kubernetes-worker/0" | awk '{print $5}')
+PUB_IP=$(juju status -m default | grep "kubernetes-worker/0" | awk '{print $5}')
 PUB_ADDR="${PUB_IP}.xip.io"
 
 juju config kubeflow-ambassador juju-external-hostname=$PUB_ADDR


### PR DESCRIPTION
There are multiple models in play when the call is made, and we need to specify which one we want.