### PR TITLE
Add overlay for using local storage in Jupyterhub

### DIFF
--- a/overlays/jupyterhub-local-storage.yml
+++ b/overlays/jupyterhub-local-storage.yml
@@ -1,0 +1,6 @@
+# Overlay for using local storage paths in Jupyterhub.
+# Use with `juju deploy bundle.yaml --overlay overlays/jupyterhub-local-storage.yml`
+applications:
+  kubeflow-jupyterhub:
+    options:
+      notebook-storage-class: local-storage


### PR DESCRIPTION
Lets user mount local paths into Jupyter Notebook instances