### PR TITLE
Add default storage class patch file

### DIFF
--- a/storage/is-default.yaml
+++ b/storage/is-default.yaml
@@ -1,0 +1,1 @@
+{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}


### PR DESCRIPTION
For setting the juju operator storage class to be non-default, as otherwise it doesn't get metadata annotations that crash jupyter-web.