### PR TITLE
Disallow Travis CI failures for Juju stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ env:
   matrix:
     - JUJU_CHANNEL=stable
     - JUJU_CHANNEL=edge
-matrix:
-  allow_failures:
-    - env: JUJU_CHANNEL=stable
 install:
   - sudo systemctl stop docker.service
   - sudo apt purge libyaml-dev


### PR DESCRIPTION
Juju 2.6 is out, and we can now run CI properly with stable