### PR TITLE
Lock kubernetes pip dependency for JupyterHub

### DIFF
--- a/charms/jupyterhub/reactive/jupyterhub.py
+++ b/charms/jupyterhub/reactive/jupyterhub.py
@@ -73,6 +73,7 @@ def start_charm():
         annotations = {}
 
     pip_installs = [
+        'kubernetes==9.0.0',
         'jhub-remote-user-authenticator',
         'jupyterhub-dummyauthenticator',
         'jupyterhub-kubespawner',
@@ -90,7 +91,6 @@ def start_charm():
                         'username': image_info.username,
                         'password': image_info.password,
                     },
-                    # TODO: Move to init containers to pip install when juju supports it
                     'command': [
                         'bash',
                         '-c',


### PR DESCRIPTION
Newer versions of kubernetes shuffled imports around, which broke kubespawner.