### PR TITLE
Bump up storage for CDK deployments

### DIFF
--- a/overlays/cdk.yml
+++ b/overlays/cdk.yml
@@ -1,0 +1,3 @@
+applications:
+  kubernetes-worker:
+    constraints: cores=4 mem=4G root-disk=100G zones=us-east-1a


### PR DESCRIPTION
All of the Docker images take a fair amount of room, and disk space is cheap, so specify 100GB disks for the worker nodes.