### PR TITLE
Update ModelDB charm configurations

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -224,6 +224,7 @@ relations:
 - [ambassador, tf-job-dashboard]
 - [katib-manager, katib-db]
 - [modeldb-backend, mariadb]
+- [modeldb-backend, modeldb-store]
 - [modeldb-backend, modeldb-ui]
 - [pipelines-api, mariadb]
 - [pipelines-api, minio]

--- a/charms/mariadb/config.yaml
+++ b/charms/mariadb/config.yaml
@@ -7,8 +7,8 @@ options:
     default: ''
   database:
     type: string
-    default: ''
-    description: If not empty, the database to create
+    default: defaultdb
+    description: The database to create
   port:
     type: int
     default: 3306

--- a/charms/mariadb/reactive/mariadb.py
+++ b/charms/mariadb/reactive/mariadb.py
@@ -1,12 +1,27 @@
 import pymysql
 from charmhelpers.core import hookenv
 from charms import layer
-from charms.reactive import set_flag, when, when_not, clear_flag
+from charms.reactive import set_flag, when, when_not, clear_flag, endpoint_from_name
 
 
 @when('charm.mariadb.started')
 def charm_ready():
     layer.status.active('')
+
+
+@when('charm.mariadb.started')
+def configure_mysql():
+    mysql = endpoint_from_name('mysql')
+
+    for i in range(len(mysql.relations)):
+        mysql.provide_database(
+            request_id=i,
+            database_name=hookenv.config('database'),
+            port=hookenv.config('port'),
+            host=hookenv.application_name(),
+            user='root',
+            password=hookenv.config('root-password'),
+        )
 
 
 @when('layer.docker-resource.oci-image.changed', 'config.changed')

--- a/charms/modeldb-backend/config.yaml
+++ b/charms/modeldb-backend/config.yaml
@@ -2,36 +2,8 @@ options:
   grpc-port:
     type: int
     default: 8085
-    description: The port that the GRPC service will listen to
+    description: GRPC service port
   http-port:
     type: int
     default: 8080
-    description: The port that the HTTP proxy service will listen to
-  config:
-    type: string
-    default: |
-      grpcServer:
-        host: modeldb-backend
-        port: 8085
-      database:
-        DBType: rdbms
-        RdbConfiguration:
-          RdbDatabaseName: mariadb
-          RdbDriver: "com.mysql.cj.jdbc.Driver"
-          RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
-          RdbUrl: "jdbc:mysql://mariadb:3306"
-          RdbUsername: root
-          RdbPassword: ""
-      artifactStore_grpcServer:
-        host: modeldb-store
-        port: 8086
-      entities:
-        projectEntity: Project
-        experimentEntity: Experiment
-        experimentRunEntity: ExperimentRun
-        artifactStoreMappingEntity: ArtifactStoreMapping
-        jobEntity: Job
-      authService:
-        host: ~
-        port: ~
-    description: /config/config.yaml
+    description: HTTP proxy port

--- a/charms/modeldb-backend/layer.yaml
+++ b/charms/modeldb-backend/layer.yaml
@@ -3,4 +3,5 @@ includes:
   - "layer:caas-base"
   - "layer:docker-resource"
   - "layer:status"
+  - "interface:mysql"
   - "interface:http"

--- a/charms/modeldb-backend/metadata.yaml
+++ b/charms/modeldb-backend/metadata.yaml
@@ -14,6 +14,8 @@ resources:
 requires:
   mysql:
     interface: mysql
+  modeldb-store:
+    interface: http
 provides:
   modeldb-backend:
     interface: http

--- a/charms/modeldb-store/layer.yaml
+++ b/charms/modeldb-store/layer.yaml
@@ -3,3 +3,4 @@ includes:
   - "layer:caas-base"
   - "layer:docker-resource"
   - "layer:status"
+  - "interface:http"

--- a/charms/modeldb-store/metadata.yaml
+++ b/charms/modeldb-store/metadata.yaml
@@ -18,3 +18,6 @@ storage:
     location: /artifacts
     multiple:
       range: 0-1
+provides:
+  modeldb-store:
+    interface: http

--- a/charms/modeldb-store/reactive/modeldb_store.py
+++ b/charms/modeldb-store/reactive/modeldb_store.py
@@ -8,6 +8,11 @@ def charm_ready():
     layer.status.active('')
 
 
+@when('modeldb-store.available')
+def configure_http(http):
+    http.configure(port=hookenv.config('port'), hostname=hookenv.application_name())
+
+
 @when('layer.docker-resource.oci-image.changed', 'config.changed')
 def update_image():
     clear_flag('charm.modeldb-store.started')


### PR DESCRIPTION
Moves modeldb-backend configuration to Python code, and fixes mysql charm to allow modeldb-backend to get connection data in configuration from relation data. Also updates modeldb-store to provide http relation.