### PR TITLE
Improve requires syntax in deploy scripts

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -36,19 +35,21 @@ def get_output(*args):
         sys.exit(1)
 
 
-def require(*commands):
+def require(*commands: str):
     """Checks that required commands are available somewhere on $PATH."""
 
-    missing = [c for c in commands if shutil.which(c) is None]
+    # Allow syntax of `command:snap-package` to control the name of the
+    # snap package to tell the user to install.
+    commands = [c.rsplit(':', 1) for c in commands]
+
+    # Check that the commands exist.
+    missing = [c for c in commands if shutil.which(c[0]) is None]
 
     if missing:
         print('Some dependencies were not found. Please install them with:\n')
 
         for command in missing:
-            # The command might be e.g. `microk8s.enable`, and we want to tell
-            # the user to install the main snap name.
-            cmd = re.sub(r"\..*", "", command)
-            print(f'    sudo snap install {cmd} --classic')
+            print(f'    sudo snap install {command[-1]} --classic')
 
         print()
         sys.exit(1)

--- a/scripts/deploy-cdk
+++ b/scripts/deploy-cdk
@@ -69,7 +69,7 @@ def parse_args():
 def create(controller: str, cdk_model: str, model: str, channel: str, build: bool, ci: bool):
     """Deploy Kubeflow to a CDK cluster."""
 
-    require('juju', 'juju-wait', 'juju-helpers.juju-kubectl', 'juju-helpers.juju-bundle')
+    require('juju', 'juju-wait', 'juju-kubectl:juju-helpers', 'juju-bundle:juju-helpers')
 
     # There's a semantic difference here, so to make the code below a
     # little more clear, this differentiates between the two. However,

--- a/scripts/deploy-microk8s
+++ b/scripts/deploy-microk8s
@@ -45,9 +45,9 @@ def create(cloud: str, controller: str, model: str, channel: str, build: bool, c
     require(
         'juju',
         'juju-wait',
-        'juju-helpers.juju-kubectl',
-        'juju-helpers.juju-bundle',
-        'microk8s.enable',
+        'juju-kubectl:juju-helpers',
+        'juju-bundle:juju-helpers',
+        'microk8s.enable:microk8s',
     )
 
     start = time.time()


### PR DESCRIPTION
Handles a snap binary of name `foo.bar` by only checking for the existence of `bar`, in case the user has it installed via a method other than snap, and allows specifying a snap package name to recommend installing instead of parsing the binary name.