### PR TITLE
Add info subcommand to deploy scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ script:
 
   - pytest
 
-  - black . --check
+  # Check everything, and make sure the extensionless scripts are included
+  - black --check . ./scripts/*
 after_failure:
   - microk8s.kubectl get pods --all-namespaces
   - juju status --format yaml

--- a/scripts/deploy-cdk
+++ b/scripts/deploy-cdk
@@ -22,12 +22,24 @@ get_output = common.get_output
 K8S_CLOUD_NAMES = {'aws': 'ec2'}
 
 
+def get_pub_addr(controller: str, model: str):
+    status = json.loads(
+        get_output('juju', 'status', '-m', f'{controller}:{model}', '--format=json')
+    )
+    pub_ip = status['applications']['kubernetes-worker']['units']['kubernetes-worker/0'][
+        'public-address'
+    ]
+
+    return f'{pub_ip}.xip.io'
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     subparser = parser.add_subparsers(dest='command', help='Subcommand to run')
     subparser.required = True
     create_args = subparser.add_parser('create')
     destroy_args = subparser.add_parser('destroy')
+    info_args = subparser.add_parser('info')
 
     create_args.add_argument(
         '--controller', default='cdkkf', help='Controller containing CDK deployment to use'
@@ -52,9 +64,7 @@ def parse_args():
         '--controller', default='cdkkf', help='The controller in which to destroy the cloud'
     )
 
-    destroy_args.add_argument(
-        '--cloud', default='cdkkf', help='The cloud to destroy'
-    )
+    destroy_args.add_argument('--cloud', default='cdkkf', help='The cloud to destroy')
     destroy_args.add_argument('--model', default='kubeflow', help='Name of model to destroy')
     destroy_args.add_argument(
         '--purge',
@@ -62,8 +72,28 @@ def parse_args():
         default=False,
         help='Remove model for realz\nDestroys storage, cloud, and ignores any charm errors.',
     )
+    info_args.add_argument('--controller', default='cdkkf', help='Juju controller name')
+    info_args.add_argument('--cdk-model', default='default', help='Juju model name')
 
     return parser.parse_args()
+
+
+def info(controller: str, model: str):
+    pub_addr = get_pub_addr(controller, model)
+
+    message = f"""
+    Kubeflow is available via the central dashboard at http://{pub_addr}/.
+
+    To tear down Kubeflow and associated infrastructure, run this command:
+
+        ./scripts/deploy-cdk destroy
+
+    For more information, see documentation at:
+
+    https://github.com/juju-solutions/bundle-kubeflow/blob/master/README.md
+    """
+
+    print(textwrap.dedent(message))
 
 
 def create(controller: str, cdk_model: str, model: str, channel: str, build: bool, ci: bool):
@@ -118,9 +148,7 @@ def create(controller: str, cdk_model: str, model: str, channel: str, build: boo
             'parameters.type=gp2',
         )
     else:
-        raise Exception(
-            f"Storage is required, but this script can't set up storage for `{cloud}`"
-        )
+        raise Exception(f"Storage is required, but this script can't set up storage for `{cloud}`")
 
     # Allow building local bundle.yaml, otherwise deploy from the charm store
     if build:
@@ -148,53 +176,16 @@ def create(controller: str, cdk_model: str, model: str, channel: str, build: boo
         check=False,
     )
 
-    # Expose the Ambassador reverse proxy and print out a success message
-    status = json.loads(get_output('juju', 'status', '-m', cdk_model, '--format=json'))
-    pub_ip = status['applications']['kubernetes-worker']['units']['kubernetes-worker/0'][
-        'public-address'
-    ]
-
-    pub_addr = f'{pub_ip}.xip.io'
+    pub_addr = get_pub_addr(controller, cdk_model)
 
     run('juju', 'config', 'ambassador', f'juju-external-hostname={pub_addr}')
     run('juju', 'expose', 'ambassador')
 
     end = time.time()
 
-    config = json.loads(get_output('juju', 'kubectl', 'config', 'view', '-ojson'))
+    print(f'\nCongratulations, Kubeflow is now available. Took {int(end - start)} seconds.')
 
-    dashboard = config['clusters'][0]['cluster']['server']
-    username = config['users'][0]['user']['username']
-    password = config['users'][0]['user']['password']
-
-    print(
-        textwrap.dedent(
-            f"""
-
-    Congratulations, Kubeflow is now available at {pub_addr}. Took {int(end - start)} seconds.
-
-    The Kubernetes dashboard is available at:
-
-        {dashboard}/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/overview?namespace={model}
-
-    The username and password are:
-
-        {username}
-        {password}
-
-    The central dashboard is available at http://{pub_addr}/
-
-    To tear down Kubeflow and associated infrastructure, run this command:
-
-        ./scripts/deploy-cdk destroy {controller}
-
-    For more information, see documentation at:
-
-    https://github.com/juju-solutions/bundle-kubeflow/blob/master/README.md
-
-    """
-        )
-    )
+    info(controller, cdk_model)
 
 
 def destroy(controller: str, cloud: str, model: str, purge: bool):
@@ -227,3 +218,5 @@ if __name__ == '__main__':
         )
     elif parsed.command == 'destroy':
         destroy(parsed.cloud, parsed.cloud, parsed.model, parsed.purge)
+    elif parsed.command == 'info':
+        info(parsed.controller, parsed.cdk_model)

--- a/scripts/deploy-microk8s
+++ b/scripts/deploy-microk8s
@@ -9,7 +9,6 @@ import subprocess
 import textwrap
 import time
 from glob import glob
-from typing import List
 
 common = importlib.import_module('common', 'common.py')
 run = common.run
@@ -23,20 +22,65 @@ def parse_args():
     subparser.required = True
     create_args = subparser.add_parser('create')
     destroy_args = subparser.add_parser('destroy')
+    info_args = subparser.add_parser('info')
 
-    create_args.add_argument('--cloud', default='microk8s', help='')
-    create_args.add_argument('--controller', default='uk8s', help='')
-    create_args.add_argument('--model', default='kubeflow', help='')
-    create_args.add_argument('--channel', default='stable', help='')
-    create_args.add_argument('--build', action='store_true', default=False, help='')
-    create_args.add_argument('--ci', action='store_true', default=False, help='')
-
-    destroy_args.add_argument('controller', default='uk8s', help='The controller to destroy')
-    destroy_args.add_argument(
-        'args', nargs='*', help='Arguments passed on to `juju destroy-controller`'
+    create_args.add_argument('--cloud', default='microk8s', help='Juju cloud name')
+    create_args.add_argument('--controller', default='uk8s', help='Juju controller name')
+    create_args.add_argument('--model', default='kubeflow', help='Juju model name')
+    create_args.add_argument('--channel', default='stable', help='Kubeflow bundle channel')
+    create_args.add_argument(
+        '--build', action='store_true', default=False, help='Build charms locally'
+    )
+    create_args.add_argument(
+        '--ci',
+        action='store_true',
+        default=False,
+        help='Deploy bundle with CI-specific modifications',
     )
 
+    destroy_args.add_argument('--controller', default='uk8s', help='The controller to destroy')
+    destroy_args.add_argument(
+        '--purge',
+        action='store_true',
+        default=False,
+        help='Destroy controller and all associated models, storage, etc.',
+    )
+
+    info_args.add_argument(
+        '--controller', default='uk8s', help='The controller to display info for'
+    )
+    info_args.add_argument('--model', default='kubeflow', help='The model to display info for')
+
     return parser.parse_args()
+
+
+def info(controller: str, model: str):
+    status = json.loads(
+        get_output('juju', 'status', '-m', f'{controller}:{model}', '--format', 'json')
+    )
+    pub_ip = status['applications']['ambassador']['units']['ambassador/0']['address']
+
+    print(
+        textwrap.dedent(
+            f"""
+
+    The central dashboard is available at http://{pub_ip}/
+
+    Run `microk8s.kubectl proxy` to be able to access the dashboard at
+
+    http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/overview?namespace={model}
+
+    To tear down Kubeflow and associated infrastructure, run this command:
+
+        ./scripts/deploy-microk8s destroy --controller {controller} --model {model}
+
+    For more information, see documentation at:
+
+    https://github.com/juju-solutions/bundle-kubeflow/blob/master/README.md
+
+    """
+        )
+    )
 
 
 def create(cloud: str, controller: str, model: str, channel: str, build: bool, ci: bool):
@@ -75,13 +119,6 @@ def create(cloud: str, controller: str, model: str, channel: str, build: bool, c
 
     run('juju', 'bootstrap', cloud, controller)
     run('juju', 'add-model', model, cloud)
-    run(
-        'juju',
-        'create-storage-pool',
-        'operator-storage',
-        'kubernetes',
-        'storage-class=microk8s-hostpath',
-    )
 
     # Allow building local bundle.yaml, otherwise deploy from the charm store
     if build:
@@ -96,47 +133,33 @@ def create(cloud: str, controller: str, model: str, channel: str, build: bool, c
 
     # General Kubernetes setup.
     for f in glob('charms/*/resources/*.yaml'):
-        run('juju', 'kubectl', 'apply', '-f', f, check=False)
+        run('juju', 'kubectl', 'apply', '-f', f)
 
     run('juju', 'config', 'ambassador', 'juju-external-hostname=localhost')
-    run('juju', 'expose', 'ambassador')
-
-    status = json.loads(
-        get_output('juju', 'status', '-m', f'{controller}:{model}', '--format', 'json')
-    )
-    pub_ip = status['applications']['ambassador']['units']['ambassador/0']['address']
 
     end = time.time()
-    print(
-        textwrap.dedent(
-            f"""
-    Congratulations, Kubeflow is now available. Took {end - start:0.2f} seconds.
 
-    Run `microk8s.kubectl proxy` to be able to access the dashboard at
+    print(f'\nCongratulations, Kubeflow is now available. Took {int(end - start)} seconds.')
 
-    http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/overview?namespace={model}
-
-    The central dashboard is available at http://{pub_ip}/
-
-    To tear down Kubeflow and associated infrastructure, run this command:
-
-    ./scripts/deploy-microk8s destroy {controller}
-
-    For more information, see documentation at:
-
-    https://github.com/juju-solutions/bundle-kubeflow/blob/master/README.md
-
-    """
-        )
-    )
+    info(controller, model)
 
 
-def destroy(controller: str, args: List[str]):
+def destroy(controller: str, purge: bool):
     """Destroy given controller."""
 
     require('juju')
 
-    run('juju', 'destroy-controller', controller, *args)
+    if purge:
+        run(
+            'juju',
+            'destroy-controller',
+            controller,
+            '-y',
+            '--destroy-all-models',
+            '--destroy-storage',
+        )
+    else:
+        run('juju', 'destroy-controller', controller)
 
 
 if __name__ == '__main__':
@@ -147,4 +170,6 @@ if __name__ == '__main__':
             parsed.cloud, parsed.controller, parsed.model, parsed.channel, parsed.build, parsed.ci
         )
     elif parsed.command == 'destroy':
-        destroy(parsed.controller, parsed.args)
+        destroy(parsed.controller, parsed.purge)
+    elif parsed.command == 'info':
+        info(parsed.controller, parsed.model)

--- a/scripts/manage-cdk
+++ b/scripts/manage-cdk
@@ -4,14 +4,16 @@
 
 import argparse
 import importlib
+import json
 import textwrap
 from typing import List
 
 import time
 
 common = importlib.import_module('common', 'common.py')
-run = common.run
+get_output = common.get_output
 require = common.require
+run = common.run
 
 
 def parse_args():
@@ -20,6 +22,7 @@ def parse_args():
     subparser.required = True
     create_args = subparser.add_parser('create')
     destroy_args = subparser.add_parser('destroy')
+    info_args = subparser.add_parser('info')
 
     create_args.add_argument('--cloud', default='aws', help='Cloud to deploy onto')
     create_args.add_argument('--region', default='us-east-1', help='Cloud region to deploy onto')
@@ -28,12 +31,52 @@ def parse_args():
     )
     create_args.add_argument('--model', default='default', help='Juju model name to spin up CDK in')
 
-    destroy_args.add_argument('controller', default='cdkkf', help='Name of controller to destroy')
+    destroy_args.add_argument('--controller', default='cdkkf', help='Name of controller to destroy')
     destroy_args.add_argument(
         'args', nargs='*', help='Arguments passed on to `juju destroy-controller`'
     )
 
+    info_args.add_argument('--controller', default='cdkkf', help='Juju controller name')
+    info_args.add_argument('--model', default='default', help='Juju model name')
+
     return parser.parse_args()
+
+
+def info(controller: str, model: str):
+    config = json.loads(
+        get_output('juju', 'kubectl', '-m', f'{controller}:{model}', 'config', 'view', '-ojson')
+    )
+
+    dashboard = config['clusters'][0]['cluster']['server']
+    username = config['users'][0]['user']['username']
+    password = config['users'][0]['user']['password']
+
+    print(
+        textwrap.dedent(
+            f"""
+
+        The Kubernetes dashboard is available at:
+
+            {dashboard}/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/overview
+
+        The username and password are:
+
+            {username}
+            {password}
+
+        To deploy Kubeflow on top of CDK, run `./scripts/deploy-cdk create`.
+
+        To tear down CDK and associated infrastructure, run this command:
+
+            ./scripts/manage-cdk destroy --controller {controller} --model {model}
+
+        For more information, see documentation at:
+
+        https://github.com/juju-solutions/bundle-kubeflow/blob/master/README.md
+
+        """
+        )
+    )
 
 
 def create(cloud: str, region: str, controller: str, model: str):
@@ -58,24 +101,9 @@ def create(cloud: str, region: str, controller: str, model: str):
 
     end = time.time()
 
-    print(
-        textwrap.dedent(
-            f"""
-        Congratulations, CDK has been deployed. Took {int(end - start)} seconds.
+    print(f'\nCongratulations, CDK is now available. Took {int(end - start)} seconds.')
 
-        To deploy Kubeflow on top of CDK, run `./scripts/deploy-cdk create`.
-
-        To tear down CDK and associated infrastructure, run this command:
-
-            ./scripts/manage-cdk destroy {controller}
-
-        For more information, see documentation at:
-
-        https://github.com/juju-solutions/bundle-kubeflow/blob/master/README.md
-
-        """
-        )
-    )
+    info(controller)
 
 
 def destroy(controller: str, args: List[str]):
@@ -93,3 +121,5 @@ if __name__ == '__main__':
         create(parsed.cloud, parsed.region, parsed.controller, parsed.model)
     elif parsed.command == 'destroy':
         destroy(parsed.controller, parsed.args)
+    elif parsed.command == 'info':
+        info(parsed.controller, parsed.model)


### PR DESCRIPTION
Allows printing out of info about deployed infrastructure whenever needed, instead of only after successful deploy.