### PR TITLE
Bump up minio charm's minimum storage size

### DIFF
--- a/charms/minio/metadata.yaml
+++ b/charms/minio/metadata.yaml
@@ -18,3 +18,4 @@ storage:
   minio-data:
     type: filesystem
     location: /data
+    minimum-size: 10G


### PR DESCRIPTION
It's very needy and doesn't like 1G space available.