### PR TITLE
Work around Juju #1839861

### DIFF
--- a/overlays/cdk.yml
+++ b/overlays/cdk.yml
@@ -1,4 +1,4 @@
 # Overlay for CDK model
 applications:
   kubernetes-worker:
-    constraints: cores=4 mem=4G root-disk=100G zones=us-east-1a
+    constraints: cores=4 mem=4G root-disk=100G

--- a/scripts/deploy-cdk
+++ b/scripts/deploy-cdk
@@ -117,6 +117,13 @@ def create(controller: str, cdk_model: str, model: str, channel: str, build: boo
     except KeyError:
         raise Exception("Couldn't determine cloud name for `juju add-k8s`!")
 
+    # Set up some storage for the new cloud, deploy Kubeflow, and wait for
+    # Kubeflow to boot up
+    if cloud_name == 'ec2':
+        run('juju', 'kubectl', 'apply', '-f', 'storage/aws-ebs.yml')
+    else:
+        raise Exception(f"Storage is required, but this script can't set up storage for `{cloud}`")
+
     with tempfile.NamedTemporaryFile() as kubeconfig:
         # Copy details of cloud locally, and tell juju about it
         run('juju', 'scp', '-m', cdk_model, 'kubernetes-master/0:~/config', kubeconfig.name)
@@ -133,22 +140,6 @@ def create(controller: str, cdk_model: str, model: str, channel: str, build: boo
         )
 
     run('juju', 'add-model', model, cloud)
-
-    # Set up some storage for the new cloud, deploy Kubeflow, and wait for
-    # Kubeflow to boot up
-    if cloud_name == 'ec2':
-        run('juju', 'kubectl', 'apply', '-f', 'storage/aws-ebs.yml')
-        run(
-            'juju',
-            'create-storage-pool',
-            'k8s-ebs',
-            'kubernetes',
-            'storage-class=juju-ebs',
-            'storage-provisioner=kubernetes.io/aws-ebs',
-            'parameters.type=gp2',
-        )
-    else:
-        raise Exception(f"Storage is required, but this script can't set up storage for `{cloud}`")
 
     # Allow building local bundle.yaml, otherwise deploy from the charm store
     if build:
@@ -172,17 +163,6 @@ def create(controller: str, cdk_model: str, model: str, channel: str, build: boo
     # General Kubernetes setup.
     for f in glob('charms/*/resources/*.yaml'):
         run('juju', 'kubectl', 'apply', '-f', f)
-
-    run(
-        'juju',
-        'kubectl',
-        'patch',
-        'sc',
-        'juju-operator-storage',
-        '-p',
-        Path('storage/is-default.yml').read_text(),
-        check=False,
-    )
 
     pub_addr = get_pub_addr(controller, cdk_model)
 

--- a/storage/aws-ebs.yml
+++ b/storage/aws-ebs.yml
@@ -4,6 +4,8 @@ metadata:
   name: k8s-ebs
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
+provisioner: kubernetes.io/aws-ebs
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/storage/is-default.yml
+++ b/storage/is-default.yml
@@ -1,1 +1,0 @@
-{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}


### PR DESCRIPTION
If we manually create a StorageClass before Juju imports a cloud, Juju will use that one instead of creating its own to back the storage pools that it creates for itself. That then lets us specify the binding mode for the storage class, and support multi-az deployments with WaitForFirstConsumer.

Juju bug link: https://bugs.launchpad.net/juju/+bug/1839861