### PR TITLE
Omit service frontends / dummy ports on charms that don't need them

### DIFF
--- a/charms/argo-controller/reactive/argo_controller.py
+++ b/charms/argo-controller/reactive/argo_controller.py
@@ -30,6 +30,7 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
+            'omitServiceFrontend': True,
             'containers': [
                 {
                     'name': 'argo-controller',
@@ -45,7 +46,6 @@ def start_charm():
                         'username': image_info.username,
                         'password': image_info.password,
                     },
-                    'ports': [{'name': 'dummy', 'containerPort': 9999}],
                     'config': {'ARGO_NAMESPACE': os.environ['JUJU_MODEL_NAME']},
                     'files': [
                         {

--- a/charms/jupyter-controller/reactive/jupyter_controller.py
+++ b/charms/jupyter-controller/reactive/jupyter_controller.py
@@ -26,6 +26,7 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
+            'omitServiceFrontend': True,
             'containers': [
                 {
                     'name': 'jupyterhub',
@@ -35,7 +36,6 @@ def start_charm():
                         'username': image_info.username,
                         'password': image_info.password,
                     },
-                    'ports': [{'name': 'dummy', 'containerPort': 9999}],
                 }
             ],
             'customResourceDefinitions': {crd['metadata']['name']: crd['spec']},

--- a/charms/pipelines-persistence/reactive/pipelines_persistence.py
+++ b/charms/pipelines-persistence/reactive/pipelines_persistence.py
@@ -26,6 +26,7 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
+            'omitServiceFrontend': True,
             'containers': [
                 {
                     'name': 'pipelines-persistence',
@@ -40,9 +41,8 @@ def start_charm():
                         'username': image_info.username,
                         'password': image_info.password,
                     },
-                    'ports': [{'name': 'dummy', 'containerPort': 9999}],
                 }
-            ]
+            ],
         }
     )
 

--- a/charms/pipelines-scheduledworkflow/reactive/pipelines_scheduledworkflow.py
+++ b/charms/pipelines-scheduledworkflow/reactive/pipelines_scheduledworkflow.py
@@ -26,6 +26,7 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
+            'omitServiceFrontend': True,
             'containers': [
                 {
                     'name': 'pipelines-scheduledworkflow',
@@ -34,7 +35,6 @@ def start_charm():
                         'username': image_info.username,
                         'password': image_info.password,
                     },
-                    'ports': [{'name': 'dummy', 'containerPort': 9999}],
                 }
             ],
             'customResourceDefinitions': {crd['metadata']['name']: crd['spec']},

--- a/charms/pytorch-operator/reactive/pytorch_operator.py
+++ b/charms/pytorch-operator/reactive/pytorch_operator.py
@@ -33,6 +33,7 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
+            'omitServiceFrontend': True,
             'containers': [
                 {
                     'name': 'pytorch-operator',
@@ -42,7 +43,6 @@ def start_charm():
                         'password': image_info.password,
                     },
                     'command': ['/pytorch-operator.v1beta1', '--alsologtostderr', '-v=1'],
-                    'ports': [{'name': 'dummy', 'containerPort': 9999}],
                     'config': {
                         'MY_POD_NAMESPACE': os.environ['JUJU_MODEL_NAME'],
                         'MY_POD_NAME': hookenv.service_name(),

--- a/charms/tf-job-operator/reactive/tf_job_operator.py
+++ b/charms/tf-job-operator/reactive/tf_job_operator.py
@@ -31,6 +31,7 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
+            'omitServiceFrontend': True,
             'containers': [
                 {
                     'name': 'tf-job-operator',
@@ -45,7 +46,6 @@ def start_charm():
                         '-v=1',
                         '--monitoring-port=8443',
                     ],
-                    'ports': [{'name': 'dummy', 'containerPort': 9999}],
                     'serviceAccountName': 'tf-job-operator',
                     'config': {
                         'MY_POD_NAMESPACE': os.environ['JUJU_MODEL_NAME'],


### PR DESCRIPTION
Juju fixed a bug where omitting a service frontend wasn't allowed, so we can now drop the service frontends and dummy ports.