### PR TITLE
Added random password generation logic

### DIFF
--- a/charms/mariadb/reactive/mariadb.py
+++ b/charms/mariadb/reactive/mariadb.py
@@ -20,6 +20,7 @@ def charm_ready():
 @when('clients.database.requested')
 def configure_mysql():
     mysql = endpoint_from_name('mysql')
+    db = unitdata.kv()
     root_password = db.get('root_password')
 
     for i in range(len(mysql.relations)):
@@ -80,6 +81,7 @@ def configure_workload():
 def configure_db():
     hookenv.log('Setting up mariadb')
 
+    db = unitdata.kv()
     root_password = db.get('root_password')
     database = hookenv.config('database')
     service = hookenv.service_name()

--- a/charms/mariadb/wheelhouse.txt
+++ b/charms/mariadb/wheelhouse.txt
@@ -1,1 +1,2 @@
 pymysql
+charmhelpers


### PR DESCRIPTION
- root-password generated randomly if not passed via config
- password saved on unitdata.kv()
- configure_mysql waits for mariadb fully configured before endpoint setup
closes #86 