### PR TITLE
Correct usage of mysql interface flags

### DIFF
--- a/charms/katib-manager/reactive/katib_manager.py
+++ b/charms/katib-manager/reactive/katib_manager.py
@@ -8,7 +8,7 @@ def charm_ready():
     layer.status.active('')
 
 
-@when('layer.docker-resource.oci-image.changed')
+@when('layer.docker-resource.oci-image.changed', 'config.changed', 'mysql.changed')
 def update_image():
     clear_flag('charm.started')
 
@@ -16,7 +16,7 @@ def update_image():
 @when(
     'layer.docker-resource.manager-image.available',
     'layer.docker-resource.restful-image.available',
-    'mysql.connected',
+    'mysql.available',
 )
 @when_not('charm.started')
 def start_charm():
@@ -67,4 +67,5 @@ def start_charm():
     )
 
     layer.status.maintenance('creating container')
+    clear_flag('mysql.changed')
     set_flag('charm.started')

--- a/charms/mariadb/reactive/mariadb.py
+++ b/charms/mariadb/reactive/mariadb.py
@@ -13,9 +13,9 @@ def charm_ready():
 def configure_mysql():
     mysql = endpoint_from_name('mysql')
 
-    for i in range(len(mysql.relations)):
+    for rel_id in mysql.relations.keys():
         mysql.provide_database(
-            request_id=i,
+            request_id=rel_id,
             database_name=hookenv.config('database'),
             port=hookenv.config('port'),
             host=hookenv.application_name(),

--- a/charms/modeldb-backend/reactive/modeldb_backend.py
+++ b/charms/modeldb-backend/reactive/modeldb_backend.py
@@ -19,7 +19,7 @@ def update_image():
     clear_flag('charm.started')
 
 
-@when('layer.docker-resource.oci-image.available', 'mysql.connected', 'modeldb-store.available')
+@when('layer.docker-resource.oci-image.available', 'mysql.available', 'modeldb-store.available')
 @when_not('charm.started')
 def start_charm():
     layer.status.maintenance('configuring container')
@@ -118,4 +118,5 @@ def start_charm():
     )
 
     layer.status.maintenance('creating container')
+    clear_flag('mysql.changed')
     set_flag('charm.started')

--- a/charms/pipelines-api/reactive/pipelines_api.py
+++ b/charms/pipelines-api/reactive/pipelines_api.py
@@ -17,12 +17,12 @@ def configure_http(http):
     http.configure(port=hookenv.config('http-port'), hostname=hookenv.application_name())
 
 
-@when('layer.docker-resource.oci-image.changed', 'config.changed')
+@when('layer.docker-resource.oci-image.changed', 'config.changed', 'mysql.changed')
 def update_image():
     clear_flag('charm.started')
 
 
-@when('layer.docker-resource.oci-image.available', 'mysql.connected', 'minio.available')
+@when('layer.docker-resource.oci-image.available', 'mysql.available', 'minio.available')
 @when_not('charm.started')
 def start_charm():
     layer.status.maintenance('configuring container')
@@ -106,4 +106,5 @@ def start_charm():
     )
 
     layer.status.maintenance('creating container')
+    clear_flag('mysql.changed')
     set_flag('charm.started')


### PR DESCRIPTION
`mysql.connected` is racy and doesn't guarantee that connection information is available, but `mysql.available` does.