### PR TITLE
Deploy specific kubernetes worker to gpu instance in overlay

### DIFF
--- a/overlays/cdk-gpu.yml
+++ b/overlays/cdk-gpu.yml
@@ -1,4 +1,6 @@
 applications:
   kubernetes-worker:
-    constraints: instance-type=p2.xlarge root-disk=16G
-    num_units: 1
+    to: ["0"]
+machines:
+  0:
+    constraints: root-disk=100G instance-type=p2.xlarge


### PR DESCRIPTION
Instead of deploying a total of 1 workers and setting all to be GPU instances, deploy the normal number of workers, and set 1 to be deployed to a GPU instance.