### PR TITLE
Switch Argo runtime executor default to kubelet

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -9,7 +9,7 @@ options:
     description: S3 key prefix
   executor:
     type: string
-    default: docker
+    default: kubelet
     description: |
       Runtime executor for workflow containers. One of `docker` or `kubelet`.
       If your cluster is using containerd, this must be set to `kubelet`.

--- a/overlays/cdk-kubeflow.yml
+++ b/overlays/cdk-kubeflow.yml
@@ -1,5 +1,0 @@
-# Overlay for Kubeflow model deployed to CDK
-applications:
-  argo-controller:
-    options:
-      executor: kubelet

--- a/scripts/deploy-cdk
+++ b/scripts/deploy-cdk
@@ -143,17 +143,9 @@ def create(controller: str, cdk_model: str, model: str, channel: str, build: boo
 
     # Allow building local bundle.yaml, otherwise deploy from the charm store
     if build:
-        args = [
-            'juju',
-            'bundle',
-            'deploy',
-            '--build',
-            '--',
-            '--overlay',
-            'overlays/cdk-kubeflow.yml',
-        ]
+        args = ['juju', 'bundle', 'deploy', '--build']
         if ci:
-            args += ['--overlay', 'overlays/ci.yml']
+            args += ['--', '--overlay', 'overlays/ci.yml']
         run(*args)
     else:
         run('juju', 'deploy', 'kubeflow', '--channel', channel)


### PR DESCRIPTION
Since both CDK and Microk8s need it, let's just default to it and allow someone that needs the docker executor to override that.