### PR TITLE
Add Argo config option for skipping Kubelet TLS verification

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -13,3 +13,9 @@ options:
     description: |
       Runtime executor for workflow containers. One of `docker` or `kubelet`.
       If your cluster is using containerd, this must be set to `kubelet`.
+  kubelet-insecure:
+    type: bool
+    default: false
+    description: |
+      If true, Argo will skip checking kubelet's TLS certificate. Has no effect
+      with other executors.

--- a/charms/argo-controller/reactive/argo_controller.py
+++ b/charms/argo-controller/reactive/argo_controller.py
@@ -55,6 +55,7 @@ def start_charm():
                                 'config': yaml.dump(
                                     {
                                         'containerRuntimeExecutor': hookenv.config('executor'),
+                                        'kubeletInsecure': hookenv.config('kubelet-insecure'),
                                         'artifactRepository': {
                                             's3': {
                                                 'bucket': hookenv.config('bucket'),


### PR DESCRIPTION
Microk8s recently hardened security, and this breaks Argo, since it's a self-signed certificate.