### PR TITLE
Make cli.py script 3.6 compatible

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -41,7 +41,7 @@ def run(*args, env: dict = None, check=True):
 
 
 def get_output(*args: str):
-    return subprocess.run(args, capture_output=True, check=True).stdout
+    return subprocess.run(args, check=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE).stdout
 
 
 def juju(*args, env=None):


### PR DESCRIPTION
`subprocess.run(..., capture_output=True)` was introduced in Python 3.7