### PR TITLE
Default ambassador auth username to admin

### DIFF
--- a/charms/ambassador-auth/config.yaml
+++ b/charms/ambassador-auth/config.yaml
@@ -5,7 +5,7 @@ options:
     description: Port to listen to
   username:
     type: string
-    default: ''
+    default: 'admin'
     description: HTTP Basic Auth username
   password:
     type: string

--- a/charms/ambassador-auth/reactive/ambassador_auth.py
+++ b/charms/ambassador-auth/reactive/ambassador_auth.py
@@ -38,8 +38,12 @@ def start_charm():
 
     port = hookenv.config('port')
 
-    username = hookenv.config('username') or 'admin'
+    username = hookenv.config('username')
     password = hookenv.config('password')
+
+    if not username:
+        layer.status.blocked('Setting a username is required!')
+        return False
 
     if not password:
         layer.status.blocked('Setting a password is required!')


### PR DESCRIPTION
It's otherwise confusing if the default is `''` and yet you need to login with `admin`. Also forces a username to be set instead of silently picking admin by default.