### PR TITLE
Fix mariadb option documentation

### DIFF
--- a/charms/mariadb/config.yaml
+++ b/charms/mariadb/config.yaml
@@ -1,8 +1,7 @@
 options:
   root-password:
     description: |
-      Password to use for the database root user. If not specified,
-      one will be generated automatically.
+      Password to use for the database root user. Required.
     type: string
     default: ''
   database:


### PR DESCRIPTION
Mariadb actually requires the password to be set, it will not automatically generate one.

Fixes #86 