### PR TITLE
Add min-juju-version to charms' metadata

### DIFF
--- a/charms/ambassador-auth/metadata.yaml
+++ b/charms/ambassador-auth/metadata.yaml
@@ -14,3 +14,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
+min-juju-version: 2.7-rc1

--- a/charms/ambassador/metadata.yaml
+++ b/charms/ambassador/metadata.yaml
@@ -14,3 +14,4 @@ resources:
 provides:
   ambassador:
     interface: ambassador
+min-juju-version: 2.7-rc1

--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -17,3 +17,4 @@ requires:
 deployment:
   type: stateless
   service: omit
+min-juju-version: 2.7-rc1

--- a/charms/argo-ui/metadata.yaml
+++ b/charms/argo-ui/metadata.yaml
@@ -14,3 +14,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
+min-juju-version: 2.7-rc1

--- a/charms/jupyter-controller/metadata.yaml
+++ b/charms/jupyter-controller/metadata.yaml
@@ -14,3 +14,4 @@ resources:
 deployment:
   type: stateless
   service: omit
+min-juju-version: 2.7-rc1

--- a/charms/jupyter-web/metadata.yaml
+++ b/charms/jupyter-web/metadata.yaml
@@ -14,3 +14,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
+min-juju-version: 2.7-rc1

--- a/charms/katib-controller/metadata.yaml
+++ b/charms/katib-controller/metadata.yaml
@@ -17,3 +17,4 @@ requires:
 provides:
   katib-controller:
     interface: http
+min-juju-version: 2.7-rc1

--- a/charms/katib-manager/metadata.yaml
+++ b/charms/katib-manager/metadata.yaml
@@ -22,3 +22,4 @@ requires:
 provides:
   katib-manager:
     interface: http
+min-juju-version: 2.7-rc1

--- a/charms/katib-ui/metadata.yaml
+++ b/charms/katib-ui/metadata.yaml
@@ -14,3 +14,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
+min-juju-version: 2.7-rc1

--- a/charms/metacontroller/metadata.yaml
+++ b/charms/metacontroller/metadata.yaml
@@ -15,3 +15,4 @@ resources:
     description: 'Backing OCI image'
     auto-fetch: true
     upstream-source: metacontroller/metacontroller:v0.3.0
+min-juju-version: 2.7-rc1

--- a/charms/minio/metadata.yaml
+++ b/charms/minio/metadata.yaml
@@ -19,3 +19,4 @@ storage:
     type: filesystem
     location: /data
     minimum-size: 10G
+min-juju-version: 2.7-rc1

--- a/charms/modeldb-backend/metadata.yaml
+++ b/charms/modeldb-backend/metadata.yaml
@@ -19,3 +19,4 @@ requires:
 provides:
   modeldb-backend:
     interface: http
+min-juju-version: 2.7-rc1

--- a/charms/modeldb-store/metadata.yaml
+++ b/charms/modeldb-store/metadata.yaml
@@ -21,3 +21,4 @@ storage:
 provides:
   modeldb-store:
     interface: http
+min-juju-version: 2.7-rc1

--- a/charms/modeldb-ui/metadata.yaml
+++ b/charms/modeldb-ui/metadata.yaml
@@ -14,3 +14,4 @@ resources:
 requires:
   modeldb-backend:
     interface: http
+min-juju-version: 2.7-rc1

--- a/charms/pipelines-api/metadata.yaml
+++ b/charms/pipelines-api/metadata.yaml
@@ -21,3 +21,4 @@ requires:
 provides:
   pipelines-api:
     interface: http
+min-juju-version: 2.7-rc1

--- a/charms/pipelines-dashboard/metadata.yaml
+++ b/charms/pipelines-dashboard/metadata.yaml
@@ -16,3 +16,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
+min-juju-version: 2.7-rc1

--- a/charms/pipelines-persistence/metadata.yaml
+++ b/charms/pipelines-persistence/metadata.yaml
@@ -16,3 +16,4 @@ resources:
 requires:
   pipelines-api:
     interface: http
+min-juju-version: 2.7-rc1

--- a/charms/pipelines-scheduledworkflow/metadata.yaml
+++ b/charms/pipelines-scheduledworkflow/metadata.yaml
@@ -16,3 +16,4 @@ resources:
 deployment:
   type: stateless
   service: omit
+min-juju-version: 2.7-rc1

--- a/charms/pipelines-ui/metadata.yaml
+++ b/charms/pipelines-ui/metadata.yaml
@@ -20,3 +20,4 @@ requires:
     interface: http
   minio:
     interface: http
+min-juju-version: 2.7-rc1

--- a/charms/pipelines-viewer/metadata.yaml
+++ b/charms/pipelines-viewer/metadata.yaml
@@ -16,3 +16,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
+min-juju-version: 2.7-rc1

--- a/charms/pytorch-operator/metadata.yaml
+++ b/charms/pytorch-operator/metadata.yaml
@@ -16,3 +16,4 @@ resources:
 deployment:
   type: stateless
   service: omit
+min-juju-version: 2.7-rc1

--- a/charms/redis/metadata.yaml
+++ b/charms/redis/metadata.yaml
@@ -23,3 +23,4 @@ resources:
 provides:
   db:
     interface: redis
+min-juju-version: 2.7-rc1

--- a/charms/seldon-api-frontend/metadata.yaml
+++ b/charms/seldon-api-frontend/metadata.yaml
@@ -19,3 +19,4 @@ resources:
 requires:
   redis:
     interface: redis
+min-juju-version: 2.7-rc1

--- a/charms/seldon-cluster-manager/metadata.yaml
+++ b/charms/seldon-cluster-manager/metadata.yaml
@@ -19,3 +19,4 @@ resources:
 requires:
   redis:
     interface: redis
+min-juju-version: 2.7-rc1

--- a/charms/tensorboard/metadata.yaml
+++ b/charms/tensorboard/metadata.yaml
@@ -21,3 +21,4 @@ storage:
     location: /logs
     multiple:
       range: 0-1
+min-juju-version: 2.7-rc1

--- a/charms/tf-job-dashboard/metadata.yaml
+++ b/charms/tf-job-dashboard/metadata.yaml
@@ -16,3 +16,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
+min-juju-version: 2.7-rc1

--- a/charms/tf-job-operator/metadata.yaml
+++ b/charms/tf-job-operator/metadata.yaml
@@ -16,3 +16,4 @@ resources:
 deployment:
   type: stateless
   service: omit
+min-juju-version: 2.7-rc1

--- a/charms/tf-serving/metadata.yaml
+++ b/charms/tf-serving/metadata.yaml
@@ -20,3 +20,4 @@ storage:
     location: /models
     multiple:
       range: 0-1
+min-juju-version: 2.7-rc1


### PR DESCRIPTION
Pod spec v2 broke backwards compatibility with 2.6, so disallow the charms from getting deployed by it.