### PR TITLE
Remove explicit operator storage while deploying

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -396,8 +396,6 @@ def setup(cloud, region, controller, channel, gpu):
             '-c',
             controller,
             f'--region={cloud}/{region}',
-            '--storage',
-            'juju-operator-storage',
             env={'KUBECONFIG': kubeconfig.name},
         )
 


### PR DESCRIPTION
Previous Juju beta versions were probably just buggy in their requirement of the CLI param, and now that's been fixed in rc1 so that it's unnecessary.

Fixes #128