### PR TITLE
List all clouds when deploying in cli.py

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -246,10 +246,10 @@ def deploy_to(controller, cloud, model, channel, build, overlays, password):
 
     # If a specific cloud wasn't passed in, try to figure out which one to use
     if not cloud:
-        clouds = json.loads(get_output('juju', 'list-clouds', '-c', controller, '--format=json'))
+        output = get_output('juju', 'list-clouds', '-c', controller, '--format=json', '--all')
         clouds = [
             name
-            for name, details in clouds.items()
+            for name, details in json.loads(output).items()
             if details['type'] == 'k8s' and details['defined'] == 'public'
         ]
         if not clouds:


### PR DESCRIPTION
There's currently a bug in Juju that requires the `--all` flag, but it won't hurt going forward to include the flag anyways.