### PR TITLE
Remove hardcoded minio usage in example pipeline

### DIFF
--- a/tests/Dockerfile.mnist
+++ b/tests/Dockerfile.mnist
@@ -3,4 +3,4 @@
 
 FROM tensorflow/tensorflow:1.14.0-py3
 
-RUN pip install minio requests retrying
+RUN pip install requests

--- a/tests/pipelines/common.py
+++ b/tests/pipelines/common.py
@@ -25,15 +25,4 @@ def attach_output_volume(op):
         k8s_client.V1VolumeMount(name='outputs', mount_path='/tmp/outputs')
     )
 
-    # Allow access to minio secrets
-    op.add_volume(
-        k8s_client.V1Volume(
-            name='minio-secrets',
-            secret=k8s_client.V1SecretVolumeSource(secret_name='mlpipeline-minio-artifact'),
-        )
-    )
-    op.container.add_volume_mount(
-        k8s_client.V1VolumeMount(name='minio-secrets', mount_path='/secrets')
-    )
-
     return op

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -11,7 +11,6 @@ COWSAY_PARAMS = [{"name": "url", "value": "https://helloacm.com/api/fortune/"}]
 
 
 MNIST_PARAMS = [
-    {'name': 'storage-endpoint', 'value': 'minio:9000'},
     {
         'name': 'test-images',
         'value': 'https://people.canonical.com/~knkski/t10k-images-idx3-ubyte.gz',


### PR DESCRIPTION
The pipelines DSL now supports passing large amounts of data natively, instead of having to manually shuffle it back and forth with minio.