### PR TITLE
Sync Katib charms with current 0.7rc from upstream

### DIFF
--- a/charms/katib-controller/files/trial-crd.yaml
+++ b/charms/katib-controller/files/trial-crd.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
     name: Status
     type: string
   - JSONPath: .metadata.creationTimestamp

--- a/charms/katib-manager/config.yaml
+++ b/charms/katib-manager/config.yaml
@@ -1,9 +1,5 @@
 options:
-  manager-port:
+  port:
     type: int
     default: 6789
-    description: Main manager port
-  restful-port:
-    type: int
-    default: 80
-    description: RESTful API port
+    description: API port

--- a/charms/katib-manager/metadata.yaml
+++ b/charms/katib-manager/metadata.yaml
@@ -6,16 +6,11 @@ maintainers: [Juju Developers <juju@lists.ubuntu.com>]
 tags: [ai, bigdata, kubeflow, machine-learning, tensorflow]
 series: [kubernetes]
 resources:
-  manager-image:
+  oci-image:
     type: oci-image
-    description: 'Main manager image'
+    description: 'Backing OCI image'
     auto-fetch: true
     upstream-source: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-manager
-  restful-image:
-    type: oci-image
-    description: 'REST API proxy image'
-    auto-fetch: true
-    upstream-source: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-manager-rest
 requires:
   mysql:
     interface: mysql

--- a/charms/katib-ui/reactive/katib_ui.py
+++ b/charms/katib-ui/reactive/katib_ui.py
@@ -1,7 +1,10 @@
+import os
+
 import yaml
+
 from charmhelpers.core import hookenv
 from charms import layer
-from charms.reactive import hook, set_flag, clear_flag, when, when_not
+from charms.reactive import clear_flag, hook, set_flag, when, when_not
 
 
 @hook('upgrade-charm')
@@ -61,7 +64,8 @@ def start_charm():
                         'username': image_info.username,
                         'password': image_info.password,
                     },
-                    'ports': [{'name': 'port', 'containerPort': 80}],
+                    'ports': [{'name': 'http', 'containerPort': 80}],
+                    'config': {'KATIB_CORE_NAMESPACE': os.environ['JUJU_MODEL_NAME']},
                 }
             ],
         }


### PR DESCRIPTION
Although the dashboard has been synced to 0.6, Katib 0.6 doesn't support custom mysql db service locations, so we need to use 0.7. Keeps Katib current with upstream's 0.7 release candidate version.