### PR TITLE
Update pipelines-persistence to pod spec v2

### DIFF
--- a/charms/pipelines-persistence/metadata.yaml
+++ b/charms/pipelines-persistence/metadata.yaml
@@ -16,4 +16,7 @@ resources:
 requires:
   pipelines-api:
     interface: http
+deployment:
+  type: stateless
+  service: omit
 min-juju-version: 2.7-rc1

--- a/charms/pipelines-persistence/reactive/pipelines_persistence.py
+++ b/charms/pipelines-persistence/reactive/pipelines_persistence.py
@@ -30,7 +30,22 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
-            'omitServiceFrontend': True,
+            'version': 2,
+            'serviceAccount': {
+                'global': True,
+                'rules': [
+                    {
+                        'apiGroups': ['argoproj.io'],
+                        'resources': ['workflows'],
+                        'verbs': ['get', 'list', 'watch'],
+                    },
+                    {
+                        'apiGroups': ['kubeflow.org'],
+                        'resources': ['scheduledworkflows'],
+                        'verbs': ['get', 'list', 'watch'],
+                    },
+                ],
+            },
             'containers': [
                 {
                     'name': 'pipelines-persistence',


### PR DESCRIPTION
It needs some permissions to function properly, and pod spec v2 also has different syntax for skipping service creation.