### PR TITLE
Add pipelines-viewer permissions

### DIFF
--- a/charms/pipelines-viewer/reactive/pipelines_viewer.py
+++ b/charms/pipelines-viewer/reactive/pipelines_viewer.py
@@ -34,6 +34,22 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
+            'version': 2,
+            'serviceAccount': {
+                'global': True,
+                'rules': [
+                    {
+                        'apiGroups': ['*'],
+                        'resources': ['deployments', 'services'],
+                        'verbs': ['create', 'get', 'list', 'watch', 'update', 'patch', 'delete'],
+                    },
+                    {
+                        'apiGroups': ['kubeflow.org'],
+                        'resources': ['viewers'],
+                        'verbs': ['create', 'get', 'list', 'watch', 'update', 'patch', 'delete'],
+                    },
+                ],
+            },
             'service': {
                 'annotations': {
                     'getambassador.io/config': yaml.dump_all(


### PR DESCRIPTION
Upgrades to pod spec v2, which allows setting necessary permissions.