### PR TITLE
Fix katib manager port reference

### DIFF
--- a/charms/katib-manager/reactive/katib_manager.py
+++ b/charms/katib-manager/reactive/katib_manager.py
@@ -27,7 +27,7 @@ def start_charm():
 
     mysql = endpoint_from_name('mysql')
 
-    port = hookenv.config('manager-port')
+    port = hookenv.config('port')
 
     layer.caas_base.pod_spec_set(
         {


### PR DESCRIPTION
The config got updated, and the Python code wasn't.