### PR TITLE
Switch to PNS executor by default in Argo

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -17,13 +17,13 @@ options:
     description: Artifact repository secret key
   executor:
     type: string
-    default: kubelet
+    default: pns
     description: |
-      Runtime executor for workflow containers. One of `docker` or `kubelet`.
-      If your cluster is using containerd, this must be set to `kubelet`.
+      Runtime executor for workflow containers. Cannot be `docker` on containerd,
+      for a full list of executors, see https://github.com/argoproj/argo/tree/master/workflow/executor
   kubelet-insecure:
     type: boolean
-    default: true
+    default: false
     description: |
       If true, Argo will skip checking kubelet's TLS certificate. Has no effect
       with other executors.

--- a/charms/pipelines-api/files/condition.yaml
+++ b/charms/pipelines-api/files/condition.yaml
@@ -132,29 +132,15 @@ spec:
       - sh
       - -c
       image: python:alpine3.6
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     name: flip-coin
     outputs:
       artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
       - name: flip-coin-output
         path: /tmp/output
       parameters:
       - name: flip-coin-output
         valueFrom:
           path: /tmp/output
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - python -c "import random; print(random.randint($0, $1))" | tee $2
@@ -165,29 +151,15 @@ spec:
       - sh
       - -c
       image: python:alpine3.6
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     name: generate-random-number
     outputs:
       artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
       - name: generate-random-number-output
         path: /tmp/output
       parameters:
       - name: generate-random-number-output
         valueFrom:
           path: /tmp/output
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - python -c "import random; print(random.randint($0, $1))" | tee $2
@@ -198,126 +170,48 @@ spec:
       - sh
       - -c
       image: python:alpine3.6
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     name: generate-random-number-2
     outputs:
       artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
       - name: generate-random-number-2-output
         path: /tmp/output
       parameters:
       - name: generate-random-number-2-output
         valueFrom:
           path: /tmp/output
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       command:
       - echo
       - heads and {{inputs.parameters.generate-random-number-output}} > 5!
       image: alpine:3.6
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: generate-random-number-output
     name: print
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       command:
       - echo
       - heads and {{inputs.parameters.generate-random-number-output}} <= 5!
       image: alpine:3.6
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: generate-random-number-output
     name: print-2
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       command:
       - echo
       - tails and {{inputs.parameters.generate-random-number-2-output}} > 15!
       image: alpine:3.6
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: generate-random-number-2-output
     name: print-3
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       command:
       - echo
       - tails and {{inputs.parameters.generate-random-number-2-output}} <= 15!
       image: alpine:3.6
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: generate-random-number-2-output
     name: print-4
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp

--- a/charms/pipelines-api/files/exit_handler.yaml
+++ b/charms/pipelines-api/files/exit_handler.yaml
@@ -24,23 +24,7 @@ spec:
       - sh
       - -c
       image: library/bash:4.4.23
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     name: echo
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - echo "$0"
@@ -49,26 +33,10 @@ spec:
       - sh
       - -c
       image: library/bash:4.4.23
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: gcs-download-data
     name: echo-2
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - dag:
       tasks:
       - arguments:
@@ -110,29 +78,15 @@ spec:
       - sh
       - -c
       image: google/cloud-sdk:216.0.0
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: url
     name: gcs-download
     outputs:
       artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
       - name: gcs-download-data
         path: /tmp/results.txt
       parameters:
       - name: gcs-download-data
         valueFrom:
           path: /tmp/results.txt
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp

--- a/charms/pipelines-api/files/parallel_join.yaml
+++ b/charms/pipelines-api/files/parallel_join.yaml
@@ -26,27 +26,11 @@ spec:
       - sh
       - -c
       image: library/bash:4.4.23
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: gcs-download-2-data
       - name: gcs-download-data
     name: echo
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - gsutil cat $0 | tee $1
@@ -56,32 +40,18 @@ spec:
       - sh
       - -c
       image: google/cloud-sdk:216.0.0
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: url1
     name: gcs-download
     outputs:
       artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
       - name: gcs-download-data
         path: /tmp/results.txt
       parameters:
       - name: gcs-download-data
         valueFrom:
           path: /tmp/results.txt
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - gsutil cat $0 | tee $1
@@ -91,32 +61,18 @@ spec:
       - sh
       - -c
       image: google/cloud-sdk:216.0.0
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: url2
     name: gcs-download-2
     outputs:
       artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
       - name: gcs-download-2-data
         path: /tmp/results.txt
       parameters:
       - name: gcs-download-2-data
         valueFrom:
           path: /tmp/results.txt
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - dag:
       tasks:
       - arguments:

--- a/charms/pipelines-api/files/sequential.yaml
+++ b/charms/pipelines-api/files/sequential.yaml
@@ -22,26 +22,10 @@ spec:
       - sh
       - -c
       image: library/bash:4.4.23
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: gcs-download-data
     name: echo
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - gsutil cat $0 | tee $1
@@ -51,32 +35,18 @@ spec:
       - sh
       - -c
       image: google/cloud-sdk:216.0.0
-      volumeMounts:
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: url
     name: gcs-download
     outputs:
       artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
       - name: gcs-download-data
         path: /tmp/results.txt
       parameters:
       - name: gcs-download-data
         valueFrom:
           path: /tmp/results.txt
-    volumes:
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - dag:
       tasks:
       - arguments:

--- a/charms/pipelines-api/files/xgboost_training_cm.yaml
+++ b/charms/pipelines-api/files/xgboost_training_cm.yaml
@@ -62,10 +62,6 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-credentials-user-gcp-sa
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: output
@@ -84,17 +80,13 @@ spec:
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
+        path: /mlpipeline-ui-metadata.json
       - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
+        path: /mlpipeline-metrics.json
     volumes:
     - name: gcp-credentials-user-gcp-sa
       secret:
         secretName: user-gcp-sa
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - kfp_component.google.dataproc
@@ -137,10 +129,6 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-credentials-user-gcp-sa
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: cluster-name
@@ -178,19 +166,13 @@ spec:
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
+        path: /mlpipeline-ui-metadata.json
       - name: dataproc-create-cluster-cluster-name
         path: /tmp/kfp/output/dataproc/cluster_name.txt
     volumes:
     - name: gcp-credentials-user-gcp-sa
       secret:
         secretName: user-gcp-sa
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - kfp_component.google.dataproc
@@ -223,10 +205,6 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-credentials-user-gcp-sa
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: cluster-name
@@ -247,20 +225,10 @@ spec:
       labels:
         add-pod-env: 'true'
     name: dataproc-delete-cluster
-    outputs:
-      artifacts:
-      - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
     volumes:
     - name: gcp-credentials-user-gcp-sa
       secret:
         secretName: user-gcp-sa
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - kfp_component.google.dataproc
@@ -302,10 +270,6 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-credentials-user-gcp-sa
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: cluster-name
@@ -345,19 +309,13 @@ spec:
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
+        path: /mlpipeline-ui-metadata.json
       - name: dataproc-submit-pyspark-job-job-id
         path: /tmp/kfp/output/dataproc/job_id.txt
     volumes:
     - name: gcp-credentials-user-gcp-sa
       secret:
         secretName: user-gcp-sa
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - kfp_component.google.dataproc
@@ -400,10 +358,6 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-credentials-user-gcp-sa
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: cluster-name
@@ -444,19 +398,13 @@ spec:
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
+        path: /mlpipeline-ui-metadata.json
       - name: dataproc-submit-pyspark-job-2-job-id
         path: /tmp/kfp/output/dataproc/job_id.txt
     volumes:
     - name: gcp-credentials-user-gcp-sa
       secret:
         secretName: user-gcp-sa
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - kfp_component.google.dataproc
@@ -502,10 +450,6 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-credentials-user-gcp-sa
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: cluster-name
@@ -548,19 +492,13 @@ spec:
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
+        path: /mlpipeline-ui-metadata.json
       - name: dataproc-submit-spark-job-job-id
         path: /tmp/kfp/output/dataproc/job_id.txt
     volumes:
     - name: gcp-credentials-user-gcp-sa
       secret:
         secretName: user-gcp-sa
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - container:
       args:
       - kfp_component.google.dataproc
@@ -605,10 +543,6 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-credentials-user-gcp-sa
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: cluster-name
@@ -649,19 +583,13 @@ spec:
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
-      - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
+        path: /mlpipeline-ui-metadata.json
       - name: dataproc-submit-spark-job-2-job-id
         path: /tmp/kfp/output/dataproc/job_id.txt
     volumes:
     - name: gcp-credentials-user-gcp-sa
       secret:
         secretName: user-gcp-sa
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - dag:
       tasks:
       - arguments:
@@ -804,10 +732,6 @@ spec:
       volumeMounts:
       - mountPath: /secret/gcp-credentials
         name: gcp-credentials-user-gcp-sa
-      - mountPath: /output
-        name: output
-      - mountPath: /tmp
-        name: tmp
     inputs:
       parameters:
       - name: output
@@ -833,17 +757,13 @@ spec:
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
-        path: /output/mlpipeline-ui-metadata.json
+        path: /mlpipeline-ui-metadata.json
       - name: mlpipeline-metrics
-        path: /output/mlpipeline-metrics.json
+        path: /mlpipeline-metrics.json
     volumes:
     - name: gcp-credentials-user-gcp-sa
       secret:
         secretName: user-gcp-sa
-    - emptyDir: {}
-      name: output
-    - emptyDir: {}
-      name: tmp
   - dag:
       tasks:
       - arguments:

--- a/pipeline-samples/condition.py
+++ b/pipeline-samples/condition.py
@@ -15,26 +15,6 @@
 
 import kfp
 from kfp import dsl
-from kubernetes import client as k8s_client
-
-
-def attach_output_volume(op):
-    op.output_artifact_paths = {
-        'mlpipeline-ui-metadata': '/output/mlpipeline-ui-metadata.json',
-        'mlpipeline-metrics': '/output/mlpipeline-metrics.json',
-    }
-
-    op.add_volume(k8s_client.V1Volume(name='output', empty_dir=k8s_client.V1EmptyDirVolumeSource()))
-    op.container.add_volume_mount(k8s_client.V1VolumeMount(name='output', mount_path='/output'))
-
-    op.add_volume(
-        k8s_client.V1Volume(name='tmp', empty_dir=k8s_client.V1EmptyDirVolumeSource())
-    )
-    op.container.add_volume_mount(
-        k8s_client.V1VolumeMount(name='tmp', mount_path='/tmp')
-    )
-
-    return op
 
 
 def random_num_op(low, high):
@@ -88,8 +68,6 @@ def flipcoin_pipeline():
             print_op('tails and %s > 15!' % random_num_tail.output)
         with dsl.Condition(random_num_tail.output <= 15):
             print_op('tails and %s <= 15!' % random_num_tail.output)
-
-    dsl.get_pipeline_conf().add_op_transformer(attach_output_volume)
 
 
 if __name__ == '__main__':

--- a/pipeline-samples/exit_handler.py
+++ b/pipeline-samples/exit_handler.py
@@ -16,26 +16,7 @@
 
 import kfp
 from kfp import dsl
-from kubernetes import client as k8s_client
 
-
-def attach_output_volume(op):
-    op.output_artifact_paths = {
-        'mlpipeline-ui-metadata': '/output/mlpipeline-ui-metadata.json',
-        'mlpipeline-metrics': '/output/mlpipeline-metrics.json',
-    }
-
-    op.add_volume(k8s_client.V1Volume(name='output', empty_dir=k8s_client.V1EmptyDirVolumeSource()))
-    op.container.add_volume_mount(k8s_client.V1VolumeMount(name='output', mount_path='/output'))
-
-    op.add_volume(
-        k8s_client.V1Volume(name='tmp', empty_dir=k8s_client.V1EmptyDirVolumeSource())
-    )
-    op.container.add_volume_mount(
-        k8s_client.V1VolumeMount(name='tmp', mount_path='/tmp')
-    )
-
-    return op
 
 def gcs_download_op(url):
     return dsl.ContainerOp(
@@ -71,7 +52,6 @@ def download_and_print(url='gs://ml-pipeline-playground/shakespeare1.txt'):
         download_task = gcs_download_op(url)
         echo_task = echo_op(download_task.output)
 
-    dsl.get_pipeline_conf().add_op_transformer(attach_output_volume)
 
 if __name__ == '__main__':
     kfp.compiler.Compiler().compile(download_and_print, __file__ + '.zip')

--- a/pipeline-samples/parallel_join.py
+++ b/pipeline-samples/parallel_join.py
@@ -16,25 +16,6 @@
 
 import kfp
 from kfp import dsl
-from kubernetes import client as k8s_client
-
-
-def attach_output_volume(op):
-    op.output_artifact_paths = {
-        'mlpipeline-ui-metadata': '/output/mlpipeline-ui-metadata.json',
-        'mlpipeline-metrics': '/output/mlpipeline-metrics.json',
-    }
-
-    op.add_volume(k8s_client.V1Volume(name='output', empty_dir=k8s_client.V1EmptyDirVolumeSource()))
-    op.container.add_volume_mount(k8s_client.V1VolumeMount(name='output', mount_path='/output'))
-
-    op.add_volume(
-        k8s_client.V1Volume(name='tmp', empty_dir=k8s_client.V1EmptyDirVolumeSource())
-    )
-    op.container.add_volume_mount(
-        k8s_client.V1VolumeMount(name='tmp', mount_path='/tmp')
-    )
-
 
 def gcs_download_op(url):
     return dsl.ContainerOp(
@@ -71,7 +52,6 @@ def download_and_join(
     download2_task = gcs_download_op(url2)
 
     echo_task = echo2_op(download1_task.output, download2_task.output)
-    dsl.get_pipeline_conf().add_op_transformer(attach_output_volume)
 
 if __name__ == '__main__':
     kfp.compiler.Compiler().compile(download_and_join, __file__ + '.zip')

--- a/pipeline-samples/sequential.py
+++ b/pipeline-samples/sequential.py
@@ -16,25 +16,6 @@
 
 import kfp
 from kfp import dsl
-from kubernetes import client as k8s_client
-
-
-def attach_output_volume(op):
-    op.output_artifact_paths = {
-        'mlpipeline-ui-metadata': '/output/mlpipeline-ui-metadata.json',
-        'mlpipeline-metrics': '/output/mlpipeline-metrics.json',
-    }
-
-    op.add_volume(k8s_client.V1Volume(name='output', empty_dir=k8s_client.V1EmptyDirVolumeSource()))
-    op.container.add_volume_mount(k8s_client.V1VolumeMount(name='output', mount_path='/output'))
-
-    op.add_volume(
-        k8s_client.V1Volume(name='tmp', empty_dir=k8s_client.V1EmptyDirVolumeSource())
-    )
-    op.container.add_volume_mount(
-        k8s_client.V1VolumeMount(name='tmp', mount_path='/tmp')
-    )
-
 
 
 def gcs_download_op(url):
@@ -66,7 +47,6 @@ def sequential_pipeline(url='gs://ml-pipeline-playground/shakespeare1.txt'):
 
     download_task = gcs_download_op(url)
     echo_task = echo_op(download_task.output)
-    dsl.get_pipeline_conf().add_op_transformer(attach_output_volume)
 
 if __name__ == '__main__':
     kfp.compiler.Compiler().compile(sequential_pipeline, __file__ + '.zip')

--- a/pipeline-samples/xgboost_training_cm.py
+++ b/pipeline-samples/xgboost_training_cm.py
@@ -21,26 +21,6 @@ from kfp import dsl
 from kfp import gcp
 import os
 import subprocess
-from kubernetes import client as k8s_client
-
-
-def attach_output_volume(op):
-    op.output_artifact_paths = {
-        'mlpipeline-ui-metadata': '/output/mlpipeline-ui-metadata.json',
-        'mlpipeline-metrics': '/output/mlpipeline-metrics.json',
-    }
-
-    op.add_volume(k8s_client.V1Volume(name='output', empty_dir=k8s_client.V1EmptyDirVolumeSource()))
-    op.container.add_volume_mount(k8s_client.V1VolumeMount(name='output', mount_path='/output'))
-
-    op.add_volume(
-        k8s_client.V1Volume(name='tmp', empty_dir=k8s_client.V1EmptyDirVolumeSource())
-    )
-    op.container.add_volume_mount(
-        k8s_client.V1VolumeMount(name='tmp', mount_path='/tmp')
-    )
-
-    return op
 
 confusion_matrix_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/02c991dd265054b040265b3dfa1903d5b49df859/components/local/confusion_matrix/component.yaml')
 
@@ -319,8 +299,6 @@ def xgb_train_pipeline(
 
     dsl.get_pipeline_conf().add_op_transformer(
         gcp.use_gcp_secret('user-gcp-sa'))
-
-    dsl.get_pipeline_conf().add_op_transformer(attach_output_volume)
 
 if __name__ == '__main__':
     kfp.compiler.Compiler().compile(xgb_train_pipeline, __file__ + '.zip')


### PR DESCRIPTION
We no longer have to hack around kubelet certificates and insecure APIs, but the upstream workflows haven't been recompiled with a more recent version of kfp, so we still need to inject those into the docker image.