### PR TITLE
Bump minimum Juju version to 2.7.0 for each charm

### DIFF
--- a/charms/ambassador/metadata.yaml
+++ b/charms/ambassador/metadata.yaml
@@ -14,4 +14,4 @@ resources:
 provides:
   ambassador:
     interface: ambassador
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -17,4 +17,4 @@ requires:
 deployment:
   type: stateless
   service: omit
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/argo-ui/metadata.yaml
+++ b/charms/argo-ui/metadata.yaml
@@ -14,4 +14,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/jupyter-controller/metadata.yaml
+++ b/charms/jupyter-controller/metadata.yaml
@@ -14,4 +14,4 @@ resources:
 deployment:
   type: stateless
   service: omit
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/jupyter-web/metadata.yaml
+++ b/charms/jupyter-web/metadata.yaml
@@ -14,4 +14,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/katib-controller/metadata.yaml
+++ b/charms/katib-controller/metadata.yaml
@@ -17,4 +17,4 @@ requires:
 provides:
   katib-controller:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/katib-manager/metadata.yaml
+++ b/charms/katib-manager/metadata.yaml
@@ -17,4 +17,4 @@ requires:
 provides:
   katib-manager:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/katib-ui/metadata.yaml
+++ b/charms/katib-ui/metadata.yaml
@@ -14,4 +14,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/kubeflow-dashboard/metadata.yaml
+++ b/charms/kubeflow-dashboard/metadata.yaml
@@ -16,4 +16,4 @@ requires:
     interface: ambassador
   kubeflow-profiles:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/metacontroller/metadata.yaml
+++ b/charms/metacontroller/metadata.yaml
@@ -15,4 +15,4 @@ resources:
     description: 'Backing OCI image'
     auto-fetch: true
     upstream-source: metacontroller/metacontroller:v0.3.0
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/metadata-api/metadata.yaml
+++ b/charms/metadata-api/metadata.yaml
@@ -17,4 +17,4 @@ requires:
 provides:
   metadata-api:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/metadata-ui/metadata.yaml
+++ b/charms/metadata-ui/metadata.yaml
@@ -16,4 +16,4 @@ requires:
     interface: ambassador
   metadata-api:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/minio/metadata.yaml
+++ b/charms/minio/metadata.yaml
@@ -19,4 +19,4 @@ storage:
     type: filesystem
     location: /data
     minimum-size: 10G
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/modeldb-backend/metadata.yaml
+++ b/charms/modeldb-backend/metadata.yaml
@@ -19,4 +19,4 @@ requires:
 provides:
   modeldb-backend:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/modeldb-store/metadata.yaml
+++ b/charms/modeldb-store/metadata.yaml
@@ -21,4 +21,4 @@ storage:
 provides:
   modeldb-store:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/modeldb-ui/metadata.yaml
+++ b/charms/modeldb-ui/metadata.yaml
@@ -14,4 +14,4 @@ resources:
 requires:
   modeldb-backend:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/pipelines-api/metadata.yaml
+++ b/charms/pipelines-api/metadata.yaml
@@ -21,4 +21,4 @@ requires:
 provides:
   pipelines-api:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/pipelines-persistence/metadata.yaml
+++ b/charms/pipelines-persistence/metadata.yaml
@@ -19,4 +19,4 @@ requires:
 deployment:
   type: stateless
   service: omit
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/pipelines-scheduledworkflow/metadata.yaml
+++ b/charms/pipelines-scheduledworkflow/metadata.yaml
@@ -16,4 +16,4 @@ resources:
 deployment:
   type: stateless
   service: omit
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/pipelines-ui/metadata.yaml
+++ b/charms/pipelines-ui/metadata.yaml
@@ -20,4 +20,4 @@ requires:
     interface: http
   minio:
     interface: http
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/pipelines-viewer/metadata.yaml
+++ b/charms/pipelines-viewer/metadata.yaml
@@ -16,4 +16,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/pytorch-operator/metadata.yaml
+++ b/charms/pytorch-operator/metadata.yaml
@@ -16,4 +16,4 @@ resources:
 deployment:
   type: stateless
   service: omit
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/redis/metadata.yaml
+++ b/charms/redis/metadata.yaml
@@ -23,4 +23,4 @@ resources:
 provides:
   db:
     interface: redis
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/seldon-api-frontend/metadata.yaml
+++ b/charms/seldon-api-frontend/metadata.yaml
@@ -19,4 +19,4 @@ resources:
 requires:
   redis:
     interface: redis
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/seldon-cluster-manager/metadata.yaml
+++ b/charms/seldon-cluster-manager/metadata.yaml
@@ -19,4 +19,4 @@ resources:
 requires:
   redis:
     interface: redis
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/tensorboard/metadata.yaml
+++ b/charms/tensorboard/metadata.yaml
@@ -21,4 +21,4 @@ storage:
     location: /logs
     multiple:
       range: 0-1
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/tf-job-dashboard/metadata.yaml
+++ b/charms/tf-job-dashboard/metadata.yaml
@@ -16,4 +16,4 @@ resources:
 requires:
   ambassador:
     interface: ambassador
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/tf-job-operator/metadata.yaml
+++ b/charms/tf-job-operator/metadata.yaml
@@ -16,4 +16,4 @@ resources:
 deployment:
   type: stateless
   service: omit
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0

--- a/charms/tf-serving/metadata.yaml
+++ b/charms/tf-serving/metadata.yaml
@@ -20,4 +20,4 @@ storage:
     location: /models
     multiple:
       range: 0-1
-min-juju-version: 2.7-rc1
+min-juju-version: 2.7.0


### PR DESCRIPTION
2.7 is now stable, so no need to rely on an RC version

Fixes #153 