### PR TITLE
Better public address handling for AWS and microk8s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python: 3.7
 sudo: required
 install:
-  - pip install black==19.3b0
+  - pip install black==19.10b0
 script:
   # Check everything, and make sure the extensionless scripts are included
   - black --check . ./scripts/*

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ Finally, you can run these commands to set up microk8s:
     python3 scripts/cli.py microk8s setup --controller uk8s
     python3 scripts/cli.py deploy-to uk8s
 
+The `deploy-to` command allows manually setting a public address that
+is used for accessing Kubeflow on MicroK8s. In some deployment scenarios,
+you may need to configure MicroK8s to use LAN DNS instead of the default
+of 8.8.8.8. To do this, edit the coredns configmap with this command:
+
+    microk8s.kubectl edit configmap -n kube-system coredns
+
+Edit the line with `8.8.8.8 8.8.4.4` to use your local DNS, e.g.
+`192.168.1.1`.
+
+
 ### Setup Charmed Kubernetes
 
 You'll also need to install the `kubectl` snap:

--- a/charms/ambassador/metadata.yaml
+++ b/charms/ambassador/metadata.yaml
@@ -14,4 +14,7 @@ resources:
 provides:
   ambassador:
     interface: ambassador
+deployment:
+  type: stateless
+  service: loadbalancer
 min-juju-version: 2.7.0

--- a/charms/ambassador/reactive/ambassador.py
+++ b/charms/ambassador/reactive/ambassador.py
@@ -49,6 +49,7 @@ def start_charm():
                     },
                 ],
             },
+            'service': {'annotations': {'metallb.universe.tf/address-pool': 'default'}},
             'containers': [
                 {
                     'name': 'ambassador',


### PR DESCRIPTION
Uses juju-generated ELB in AWS instead of kubernetes worker IP. Also uses metallb on microk8s, unless a public address is manually specified. Also updates README with instructions for overriding public address.