### PR TITLE
Fix dex-auth charm for Juju 2.8

### DIFF
--- a/charms/dex-auth/wheelhouse.txt
+++ b/charms/dex-auth/wheelhouse.txt
@@ -1,2 +1,0 @@
-bcrypt
-cffi


### PR DESCRIPTION
Check that we're the leader before calling pod spec set, due to Juju bug #1875481. Also, Juju 2.8 uses a different version of Python than the charm snap, so we can't install precompiled dependencies via the wheelhouse.txt mechanism, we have to handle installing during import.