### PR TITLE
Add READMEs for each charm

### DIFF
--- a/charms/ambassador/README.md
+++ b/charms/ambassador/README.md
@@ -1,0 +1,7 @@
+Charmed Ambassador
+==================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.getambassador.io/

--- a/charms/argo-controller/README.md
+++ b/charms/argo-controller/README.md
@@ -1,0 +1,7 @@
+Charmed Argo
+============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://argoproj.github.io/docs/argo/readme.html

--- a/charms/argo-ui/README.md
+++ b/charms/argo-ui/README.md
@@ -1,0 +1,7 @@
+Charmed Argo
+============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://argoproj.github.io/docs/argo/readme.html

--- a/charms/dex-auth/README.md
+++ b/charms/dex-auth/README.md
@@ -1,0 +1,7 @@
+Charmed Dex
+===========
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://github.com/dexidp/dex

--- a/charms/jupyter-controller/README.md
+++ b/charms/jupyter-controller/README.md
@@ -1,0 +1,7 @@
+Charmed Jupyter
+===============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://jupyter.org/

--- a/charms/jupyter-web/README.md
+++ b/charms/jupyter-web/README.md
@@ -1,0 +1,8 @@
+Charmed Jupyter
+===============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://jupyter.org/
+

--- a/charms/katib-controller/README.md
+++ b/charms/katib-controller/README.md
@@ -1,0 +1,7 @@
+Charmed Katib
+=============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/hyperparameter-tuning/

--- a/charms/katib-manager/README.md
+++ b/charms/katib-manager/README.md
@@ -1,0 +1,7 @@
+Charmed Katib
+=============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/hyperparameter-tuning/

--- a/charms/katib-ui/README.md
+++ b/charms/katib-ui/README.md
@@ -1,0 +1,7 @@
+Charmed Katib
+=============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/hyperparameter-tuning/

--- a/charms/kubeflow-dashboard/README.md
+++ b/charms/kubeflow-dashboard/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Dashboard
+==========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/central-dash/

--- a/charms/kubeflow-profiles/README.md
+++ b/charms/kubeflow-profiles/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Profiles
+=========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/multi-tenancy/

--- a/charms/metacontroller/README.md
+++ b/charms/metacontroller/README.md
@@ -1,0 +1,7 @@
+Charmed Metacontroller
+======================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://metacontroller.app/

--- a/charms/metadata-api/README.md
+++ b/charms/metadata-api/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Metadata
+=========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/metadata/

--- a/charms/metadata-envoy/README.md
+++ b/charms/metadata-envoy/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Metadata
+=========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/metadata/

--- a/charms/metadata-grpc/README.md
+++ b/charms/metadata-grpc/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Metadata
+=========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/metadata/

--- a/charms/metadata-ui/README.md
+++ b/charms/metadata-ui/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Metadata
+=========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/metadata/

--- a/charms/minio/README.md
+++ b/charms/minio/README.md
@@ -1,0 +1,7 @@
+Charmed MinIO
+=============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://min.io/

--- a/charms/modeldb-backend/README.md
+++ b/charms/modeldb-backend/README.md
@@ -1,0 +1,7 @@
+Charmed ModelDB
+===============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://github.com/VertaAI/modeldb

--- a/charms/modeldb-store/README.md
+++ b/charms/modeldb-store/README.md
@@ -1,0 +1,7 @@
+Charmed ModelDB
+===============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://github.com/VertaAI/modeldb

--- a/charms/modeldb-ui/README.md
+++ b/charms/modeldb-ui/README.md
@@ -1,0 +1,7 @@
+Charmed ModelDB
+===============
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://github.com/VertaAI/modeldb

--- a/charms/oidc-gatekeeper/README.md
+++ b/charms/oidc-gatekeeper/README.md
@@ -1,0 +1,7 @@
+Charmed OIDC Gatekeeper
+=======================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://github.com/arrikto/oidc-authservice

--- a/charms/pipelines-api/README.md
+++ b/charms/pipelines-api/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Pipelines
+==========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/pipelines/

--- a/charms/pipelines-persistence/README.md
+++ b/charms/pipelines-persistence/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Pipelines
+==========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/pipelines/

--- a/charms/pipelines-scheduledworkflow/README.md
+++ b/charms/pipelines-scheduledworkflow/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Pipelines
+==========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/pipelines/

--- a/charms/pipelines-ui/README.md
+++ b/charms/pipelines-ui/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Pipelines
+==========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/pipelines/

--- a/charms/pipelines-viewer/README.md
+++ b/charms/pipelines-viewer/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Pipelines
+==========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/pipelines/

--- a/charms/pipelines-visualization/README.md
+++ b/charms/pipelines-visualization/README.md
@@ -1,0 +1,7 @@
+Charmed Kubeflow Pipelines
+==========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/pipelines/

--- a/charms/pytorch-operator/README.md
+++ b/charms/pytorch-operator/README.md
@@ -1,0 +1,7 @@
+Charmed PyTorch Operator
+========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://github.com/kubeflow/pytorch-operator

--- a/charms/seldon-core/README.md
+++ b/charms/seldon-core/README.md
@@ -1,0 +1,7 @@
+Charmed Seldon Core
+===================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://docs.seldon.io/projects/seldon-core/en/latest/

--- a/charms/tensorboard/README.md
+++ b/charms/tensorboard/README.md
@@ -1,0 +1,7 @@
+Charmed TensorBoard
+===================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.tensorflow.org/tensorboard/

--- a/charms/tf-job-operator/README.md
+++ b/charms/tf-job-operator/README.md
@@ -1,0 +1,7 @@
+Charmed TensorFlow Operator
+===========================
+
+This charm is part of the Kubeflow bundle. For instructions on how to deploy it,
+see https://jaas.ai/kubeflow.
+
+Upstream documentation can be found at https://www.kubeflow.org/docs/components/training/tftraining/


### PR DESCRIPTION
Very basic, but will prevent jaas.ai from showing the README from each charm's underlying layers, which is confusing behavior.