### PR TITLE
Clarified setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ make up this bundle can be found under `charms/`.
 
 ### Setup
 
-Setting up this bundle requires a Ubuntu VM.
+Setting up this bundle requires a Ubuntu installation or VM.
 
 > If you are on macOS or Windows, you will need to use an Ubuntu VM. You
 > can [install multipass][multipass] and access an Ubuntu VM with these

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ make up this bundle can be found under `charms/`.
 
 ### Setup
 
-If you are on macOS or Windows, you will need to use an Ubuntu VM. You
-can [install multipass][multipass] and access an Ubuntu VM with these
-commands:
+Setting up this bundle requires a Ubuntu VM.
 
-    multipass launch --name kubeflow --mem 16G
-    multipass shell kubeflow
+> If you are on macOS or Windows, you will need to use an Ubuntu VM. You
+> can [install multipass][multipass] and access an Ubuntu VM with these
+> commands:
+>
+> ```
+> multipass launch --name kubeflow --mem 16G
+> multipass shell kubeflow
+> ```
 
 16G is the recommended amount of memory to apportion the VM. Less than that
 may run into issues with pods not coming up properly.


### PR DESCRIPTION
- Made clear that you need Ubuntu to install this bundle. 
- Format Mac/Windows instructions as a block quote so users don't assume that the entire setup is **only** for Mac/Windows

Fixes #216 