### PR TITLE
Order bundle releases

### DIFF
--- a/.github/workflows/publish-bundle.yaml
+++ b/.github/workflows/publish-bundle.yaml
@@ -6,8 +6,8 @@ on:
       - master
 
 jobs:
-  full:
-    name: full
+  all bundles:
+    name: All Bundles
     runs-on: ubuntu-latest
 
     steps:
@@ -28,52 +28,7 @@ jobs:
         echo $CHARMSTORE_CREDENTIAL > ~/.go-cookies
         git clone git://git.launchpad.net/canonical-osm
         cp -r canonical-osm/charms/interfaces/juju-relation-mysql mysql
-        juju-bundle publish -b bundle.yaml --url cs:~kubeflow-charmers/kubeflow --serial --prune
-
-  lite:
-    name: lite
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Install dependencies
-      run: |
-        set -eux
-        sudo snap install charm --classic
-        sudo snap install juju-helpers --classic --channel edge
-
-    - name: Publish bundle
-      env:
-        CHARMSTORE_CREDENTIAL: ${{ secrets.CHARMSTORE_CREDENTIAL }}
-      run: |
-        set -eux
-        echo $CHARMSTORE_CREDENTIAL > ~/.go-cookies
-        git clone git://git.launchpad.net/canonical-osm
-        cp -r canonical-osm/charms/interfaces/juju-relation-mysql mysql
+        juju-bundle publish -b bundle.yaml --url cs:~kubeflow-charmers/kubeflow --serial --prune --publish-charms
         juju-bundle publish -b bundle-lite.yaml --url cs:~kubeflow-charmers/kubeflow-lite
-
-  edge:
-    name: edge
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Install dependencies
-      run: |
-        set -eux
-        sudo snap install charm --classic
-        sudo snap install juju-helpers --classic --channel edge
-
-    - name: Publish bundle
-      env:
-        CHARMSTORE_CREDENTIAL: ${{ secrets.CHARMSTORE_CREDENTIAL }}
-      run: |
-        set -eux
-        echo $CHARMSTORE_CREDENTIAL > ~/.go-cookies
-        git clone git://git.launchpad.net/canonical-osm
-        cp -r canonical-osm/charms/interfaces/juju-relation-mysql mysql
         juju-bundle publish -b bundle-edge.yaml --url cs:~kubeflow-charmers/kubeflow-edge
+


### PR DESCRIPTION
Goes in conjunction with https://github.com/knkski/rust-libjuju/commit/6cf05b5

First publishes the full bundle, and uploads the charms from the local repo. Then publishes the lite and edge bundles, reusing the already-pushed charms from the full bundle upload. This ensures that the various bundles actually use the same charm revisions, for sanity's sake.