### PR TITLE
Fix github action name

### DIFF
--- a/.github/workflows/publish-bundle.yaml
+++ b/.github/workflows/publish-bundle.yaml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  all bundles:
+  all-bundles:
     name: All Bundles
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Though YAML allows spaces in keys, GitHub doesn't like them