### PR TITLE
Fix handling of lite bundle in cli.py

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -364,6 +364,7 @@ def deploy_to(controller, cloud, model, bundle, channel, public_address, build, 
             'validatingwebhookconfigurations/katib-validating-webhook-config',
         )
 
+    if bundle in ('full', 'lite'):
         pub_addr = public_address or get_pub_addr(controller)
         juju('config', 'dex-auth', f'public-url=http://{pub_addr}:80')
         juju('config', 'oidc-gatekeeper', f'public-url=http://{pub_addr}:80')


### PR DESCRIPTION
The lite bundle includes the dashboard, and so needs the public address to be set.