### PR TITLE
Handle empty output from juju list-clouds

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -294,7 +294,7 @@ def deploy_to(controller, cloud, model, bundle, channel, public_address, build, 
             sys.exit(1)
         clouds = [
             name
-            for name, details in json.loads(output).items()
+            for name, details in (json.loads(output) or {}).items()
             if details['type'] == 'k8s' and details['defined'] == 'public'
         ]
         if not clouds:


### PR DESCRIPTION
Parsing the output from juju list-clouds can return `None`. Replace that value with `{}`, so that the call to `.items()` succeeds, and just returns an empty list.