### PR TITLE
Fixed svg images for authentication docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -24,7 +24,7 @@ The authentication flow for an unauthenticated request consists of these steps:
 The flow of an unauthenticated request is shown here:
 
 <img
-    src="dex-unauthenticated.svg"
+    src="img/dex-unauthenticated.svg"
     alt="Unauthenticated Request"
     height="500" />
 

--- a/docs/img/dex-authenticated.svg
+++ b/docs/img/dex-authenticated.svg
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" xmlns:bx="https://boxy-svg.com">
   <style>
     text {
       font: small Verdana, Helvetica, Arial, sans-serif;
@@ -33,35 +33,105 @@
       100% { opacity: 1; }
     }
   </style>
-  <marker id="triangle"
-    viewBox="0 0 10 10"
-    refX="0"
-    refY="5" 
-    markerUnits="strokeWidth"
-    markerWidth="4"
-    markerHeight="3"
-    orient="auto">
-    <path d="M 0 0 L 10 5 L 0 10 z" />
+  <marker id="triangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z"/>
   </marker>
-  <text class="step step1" x="25" y="232.5">GET /foo</text>
-	<line class="step step1" x1="20" y1="237.5" x2="85" y2="237.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step2" x="60" y="150">Authorized?</text>
-	<line class="step step2" x1="137.5" y1="180" x2="137.5" y2="120" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step3" x="175" y="150">Yes</text>
-  <line class="step step3" x1="162.5" y1="120" x2="162.5" y2="180" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step1" x="225" y="232.5">GET /foo</text>
-	<line class="step step1" x1="220" y1="237.5" x2="285" y2="237.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-	
-  <line class="step step4" x1="285" y1="262.5" x2="220" y2="262.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-  <text class="step step4" x="225" y="267.5" dominant-baseline="hanging">200 /foo</text>
-  
-  <line class="step step4" x1="85" y1="262.5" x2="20" y2="262.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-  <text class="step step4" x="25" y="267.5" dominant-baseline="hanging">200 /foo</text>
-
-  <image height="100" width="100" x="100" y="0" xlink:href="oidc.svg"><title>OIDC Gatekeeper</title></image>
-  <image height="100" width="100" x="100" y="200" xlink:href="ambassador.svg"><title>Ambassador</title></image>
-  <image height="100" width="100" x="300" y="200" xlink:href="kubeflow.svg"><title>Kubeflow</title></image>
+  <text class="step step1" x="25" y="232.5" style="white-space: pre;">GET /foo</text>
+  <line class="step step1" x1="20" y1="237.5" x2="85" y2="237.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step2" x="60" y="150" style="white-space: pre;">Authorized?</text>
+  <line class="step step2" x1="137.5" y1="180" x2="137.5" y2="120" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step3" x="175" y="150" style="white-space: pre;">Yes</text>
+  <line class="step step3" x1="162.5" y1="120" x2="162.5" y2="180" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step1" x="225" y="232.5" style="white-space: pre;">GET /foo</text>
+  <line class="step step1" x1="220" y1="237.5" x2="285" y2="237.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <line class="step step4" x1="285" y1="262.5" x2="220" y2="262.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step4" x="225" y="267.5" dominant-baseline="hanging" style="white-space: pre;">200 /foo</text>
+  <line class="step step4" x1="85" y1="262.5" x2="20" y2="262.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step4" x="25" y="267.5" dominant-baseline="hanging" style="white-space: pre;">200 /foo</text>
+  <g data-name="Layer 2" id="g28" transform="matrix(0.540862, 0, 0, 0.540862, 271.867065, 204.602737)">
+    <g data-name="Layer 1" id="g26">
+      <path d="m 103.455,53.639996 4.1,102.100004 73.75,-94.120004 a 6.79,6.79 0 0 1 9.6,-1.11 l 46,36.92 -15,-65.61 z" id="path10" style="fill:#4279f4"/>
+      <path d="m 110.105,174.47 h 65.42 l -40.17,-32.23 z" id="path12" style="fill:#0028aa"/>
+      <path d="m 187.735,75.409996 -44,56.140004 46.88,37.61 44.47,-55.76 z" id="path14" style="fill:#014bd1"/>
+      <path d="m 91.115,43.789996 0.01,-0.01 38.69,-48.52 -62.39,30.05 -15.41,67.51 z" id="path16" style="fill:#bedcff"/>
+      <path d="m 52.875,113.54 41.44,51.96 -3.95,-98.980004 z" id="path18" style="fill:#6ca1ff"/>
+      <path d="m 209.865,20.219996 -59.66,-28.73 -37.13,46.56 z" id="path20" style="fill:#a1c3ff"/>
+    </g>
+  </g>
+  <filter filterUnits="objectBoundingBox" height="3.6670001" id="filter-1" width="1.3" x="-0.15000001" y="-1.3330001">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="4" id="feGaussianBlur135"/>
+  </filter>
+  <g id="Page-1" transform="matrix(0.412266, 0, 0, 0.412266, 95.922829, 201.056168)" bx:origin="0.500114 0.5">
+    <g id="Ambassador" transform="translate(-25,-10)">
+      <g id="Group-4" transform="translate(0,4)">
+        <g id="Group-2" transform="translate(12)">
+          <g id="Group-17-Copy-2" transform="translate(0,54)">
+            <g id="Group-16">
+              <g id="Oval-8-Copy-10" class="st0" style="opacity:0.20379998;filter:url(#filter-1);enable-background:new">
+                <ellipse cx="153.39999" cy="187.5" rx="40" ry="4.5" id="ellipse138"/>
+              </g>
+              <g id="Group-12-Copy-8" transform="translate(52,164)">
+                <path id="Line-Copy-18" d="m 83.5,4.2 c -0.7,0 -1.2,0.6 -1.2,1.2 l 0.5,14 c 0,0.7 0.6,1.2 1.2,1.2 l 5.6,-0.2 c 0.7,0 1.2,-0.6 1.2,-1.2 L 90.3,5.2 C 90.3,4.5 89.7,4 89.1,4 Z"/>
+                <path id="Rectangle-7-Copy-15" d="m 70.4,17.4 c 0,-1.3 1.1,-2.4 2.4,-2.4 H 83 c 1.3,0 2.4,1.1 2.4,2.4 v 1.1 c 0,0.6 -0.4,1 -1,1 l -11.6,0.3 c -1.3,0.1 -2.4,-1 -2.4,-2.4 z"/>
+              </g>
+              <g id="Group-12-Copy-10" transform="matrix(-1,0,0,1,117,164)">
+                <path id="Line-Copy-18_1_" d="m -57.4,4.2 c -0.7,0 -1.2,0.6 -1.2,1.2 l 0.5,14 c 0,0.7 0.6,1.2 1.2,1.2 l 5.6,-0.2 c 0.7,0 1.2,-0.6 1.2,-1.2 l -0.5,-14 C -50.6,4.5 -51.2,4 -51.8,4 Z"/>
+                <path id="Rectangle-7-Copy-15_1_" d="m -70.4,17.4 c 0,-1.3 1.1,-2.4 2.4,-2.4 h 10.2 c 1.3,0 2.4,1.1 2.4,2.4 v 1.1 c 0,0.6 -0.4,1 -1,1 L -68,19.8 c -1.4,0.1 -2.4,-1 -2.4,-2.4 z"/>
+              </g>
+              <path id="Combined-Shape" d="m 145.8,3 c 3.4,4.2 12.7,9.7 24.3,13.9 12,4.4 23,6.1 28.1,4.9 7,9.4 10.4,21.6 8.9,35 l -11,92.4 c -1.4,12.1 -12.5,21.9 -24.6,21.9 h -36 c -12.1,0 -23.2,-9.8 -24.6,-21.9 L 99.9,56.8 C 96.4,27.7 116.8,4 145.8,3 Z m 10.8,0 h 2.7 c 12.3,0 23.1,4.1 31.4,10.9 -1,2.5 -9.4,1.7 -18.8,-1.8 C 164.2,9.3 158.1,5.6 156.6,3 Z"/>
+              <g id="Group" transform="translate(42,27)">
+                <g id="Group-3" transform="translate(43)">
+                  <path id="Oval-3-Copy-4" class="st1" d="m 95.2,29.6 c 7.8,-4.5 10.5,-14.5 6,-22.3 -4.5,-7.8 -28.3,16.4 -28.3,16.4 0,0 14.5,10.4 22.3,5.9 z" style="fill:#ffffff"/>
+                  <ellipse id="Oval-3-Copy-5" cx="82.199997" cy="19.299999" rx="5.3000002" ry="5.1999998"/>
+                </g>
+                <g id="Group-3-Copy" transform="matrix(-1,0,0,1,39,0)">
+                  <path id="Oval-3-Copy-4_1_" class="st1" d="m -45.7,29.6 c 7.8,-4.5 10.5,-14.5 6,-22.3 -4.5,-7.8 -28.3,16.4 -28.3,16.4 0,0 14.5,10.4 22.3,5.9 z" style="fill:#ffffff"/>
+                  <ellipse id="Oval-3-Copy-5_1_" cx="-58.700001" cy="19.299999" rx="5.3000002" ry="0"/>
+                </g>
+              </g>
+              <path id="Combined-Shape-Copy-13" d="m 106.9,122.5 -5.7,-10.7 1.8,-0.9 5,9.5 1,-2.1 -4.8,-9.1 1.8,-0.9 4.1,7.8 1,-2.1 -3.9,-7.4 1.8,-0.9 3.3,6.1 4.4,-8.8 c 0,0 -7.1,-17.9 -8.4,-22.2 C 106,73.5 85,76 83.6,88.2 c -1.4,12.3 18.7,43.4 18.7,43.4 z"/>
+              <path id="Combined-Shape-Copy-4" d="m 232.9,65.2 -10.1,6.8 1.1,1.7 8.9,-6 -0.1,2.3 -8.5,5.7 1.1,1.7 7.3,-4.9 -0.1,2.3 -6.9,4.7 1.1,1.7 5.7,-3.9 -0.3,9.8 c 0,0 -14.6,12.4 -17.8,15.6 C 208.9,108.1 191.6,96 196.1,84.5 200.8,73 233.2,55 233.2,55 Z"/>
+              <polygon id="Rectangle-2-Copy-18" class="st1" points="194.3,156.7 114.8,157.6 102.4,69 154,114.7 204.9,66.3 " style="fill:#ffffff"/>
+              <g id="Rectangle-2-Copy-17">
+                <g id="g159">
+                  <polygon id="path-2" class="st2" points="154.6,172.6 145.8,177.4 131.8,179.4 112.8,165 108,126.6 102.6,72.2 155.3,150.8 204.2,74.5 199.7,120 195.6,164.1 179.8,179.4 164.7,178.4 " style="fill:#333333"/>
+                </g>
+                <path class="st3" d="m 108.5,126.5 4.8,38.2 18.6,14.1 13.7,-2 8.9,-4.8 10.3,5.8 14.8,1 15.5,-14.9 4.1,-43.9 4.3,-43.5 -48.2,75.2 -52,-77.6 z" id="path161" style="fill:none;stroke:#000000"/>
+              </g>
+              <path id="Rectangle-4-Copy-7" class="st4" d="m 152.2,59.4 c 0.8,-0.8 2,-0.8 2.8,0 l 9.9,9.9 c 0.8,0.8 0.6,1.8 -0.4,2.3 l -8.6,4.3 c -1,0.5 -2.6,0.5 -3.6,0.1 l -9.6,-4.4 c -1,-0.5 -1.2,-1.5 -0.4,-2.2 z" style="fill:#f5a623"/>
+            </g>
+          </g>
+          <g id="Group_1_" transform="rotate(20,46.247574,262.28303)">
+            <path id="Shape" d="m 115.2,21.5 c 0.1,1.4 0.2,2.9 0.4,4.3 0,2.6 -8.2,4.8 -18.3,4.8 C 87.2,30.6 79,28.5 79,25.8 v 0 c 0.2,-1.4 0.3,-2.8 0.4,-4.3 -7.4,1.4 -12.2,3.7 -12.2,6.3 0,4.3 13.5,7.9 30.1,7.9 16.6,0 30.1,-3.5 30.1,-7.9 -0.1,-2.6 -4.8,-4.9 -12.2,-6.3 z"/>
+            <path id="Shape_1_" class="st5" d="m 116.5,-7.5 c -0.6,2.8 -7.9,5 -19.2,5 -11.4,0 -18.7,-2.2 -19.2,-5 0,0 2.2,17.3 1.4,34 0.8,2.4 8.5,4.2 17.8,4.2 9.3,0 17,-1.9 17.8,-4.2 -0.8,-16.8 1.4,-34 1.4,-34 z" style="fill:#e54733"/>
+            <path id="Shape-Copy" d="m 118.5,-14.2 c -0.6,2.8 -9.9,5 -21.2,5 -11.4,0 -20.7,-2.2 -21.2,-5 0,0 4.2,17.3 3.4,34 0.8,2.4 8.5,4.2 17.8,4.2 9.3,0 17,-1.9 17.8,-4.2 -0.8,-16.7 3.4,-34 3.4,-34 z"/>
+            <path id="Shape_2_" d="m 118.6,-15.5 c 0,0.1 0,0.2 0,0.3 -0.6,2.8 -9.9,5 -21.2,5 -11.4,0 -20.7,-2.2 -21.2,-5 0,-0.1 0,-0.2 0,-0.3 0,-2.9 9.5,-5.3 21.3,-5.3 11.5,0 21.1,2.4 21.1,5.3 z"/>
+          </g>
+          <path id="Path-8-Copy" class="st6" d="m 132.6,139.7 c -0.9,-0.6 -1.6,-0.2 -1.5,0.9 l 2.1,26 c 0.1,1.1 0.9,1.5 1.8,0.9 L 174.7,140 c 0.9,-0.6 1.6,-0.2 1.6,0.9 v 25.3 c 0,1.1 -0.8,1.5 -1.7,0.9 z" style="fill:#e64934;stroke:#000000"/>
+          <g id="Group-2-Copy" transform="translate(81,174)">
+            <circle id="Oval-10-Copy" cx="72.400002" cy="5" r="2"/>
+            <circle id="Oval-10-Copy-2" cx="72.400002" cy="13" r="2"/>
+          </g>
+          <g id="SR-71-Copy-4" transform="rotate(-56,108.8957,180.16374)">
+            <g id="g177">
+              <path id="path-3" class="st2" d="m 133.7,239.1 v -0.6 c 0,-0.6 0.2,-1.1 0.5,-1.4 0.4,-0.3 0.8,-0.5 1.4,-0.5 0.3,0 0.5,0 0.8,0 0.9,0 1.7,0.1 2.3,0.4 v 1.5 c -0.6,-0.1 -1.4,-0.1 -2.4,-0.1 -0.3,0 -0.5,0 -0.6,0.1 -0.1,0 -0.2,0.2 -0.2,0.4 v 0.1 c 0,0.2 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.5,0.1 h 0.9 c 0.8,0 1.3,0.3 1.7,1 0.1,0.3 0.2,0.7 0.2,1.1 v 0.3 c 0,1.5 -0.7,2.2 -2,2.2 -1,0 -1.6,0 -1.9,0 -0.3,0 -0.7,-0.1 -1.2,-0.3 v -1.5 c 0.7,0.1 1.6,0.1 2.6,0.1 0.2,0 0.4,0 0.5,-0.1 0.1,-0.1 0.1,-0.2 0.1,-0.3 v -0.2 c 0,-0.2 0,-0.3 -0.1,-0.3 -0.1,-0.1 -0.2,-0.1 -0.4,-0.1 h -0.9 c -0.4,0 -0.7,-0.1 -0.9,-0.2 -0.3,-0.1 -0.5,-0.3 -0.6,-0.4 -0.1,-0.2 -0.2,-0.3 -0.3,-0.6 -0.1,-0.4 -0.1,-0.8 -0.1,-1.1 z m 6,4.8 v -7.3 h 3.3 c 0.7,0 1.3,0.2 1.7,0.5 0.4,0.4 0.6,1 0.6,1.8 0,0.8 -0.1,1.4 -0.4,1.7 -0.1,0.1 -0.2,0.3 -0.3,0.3 -0.1,0 -0.2,0.1 -0.4,0.2 l 1.3,2.8 h -2.2 l -0.9,-2.6 -0.6,-0.1 v 2.7 z m 1.9,-4.2 h 1.1 c 0.2,0 0.4,-0.1 0.4,-0.2 0.1,-0.1 0.1,-0.3 0.1,-0.6 0,-0.3 0,-0.5 -0.1,-0.6 -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 h -1.1 z m 4,2.1 v -1.5 h 3.1 v 1.5 z m 3.6,-3.5 v -1.7 h 4.8 l 0.5,0.8 -2.3,6.5 h -2.1 l 2,-5.6 z m 8.8,-1.7 v 7.3 h -1.9 v -5.5 l -1.2,0.2 v -1.2 l 1.2,-0.8 z" style="fill:#333333"/>
+            </g>
+            <g id="g180">
+              <path id="path-3_1_" d="m 133.7,239.1 v -0.6 c 0,-0.6 0.2,-1.1 0.5,-1.4 0.4,-0.3 0.8,-0.5 1.4,-0.5 0.3,0 0.5,0 0.8,0 0.9,0 1.7,0.1 2.3,0.4 v 1.5 c -0.6,-0.1 -1.4,-0.1 -2.4,-0.1 -0.3,0 -0.5,0 -0.6,0.1 -0.1,0 -0.2,0.2 -0.2,0.4 v 0.1 c 0,0.2 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.5,0.1 h 0.9 c 0.8,0 1.3,0.3 1.7,1 0.1,0.3 0.2,0.7 0.2,1.1 v 0.3 c 0,1.5 -0.7,2.2 -2,2.2 -1,0 -1.6,0 -1.9,0 -0.3,0 -0.7,-0.1 -1.2,-0.3 v -1.5 c 0.7,0.1 1.6,0.1 2.6,0.1 0.2,0 0.4,0 0.5,-0.1 0.1,-0.1 0.1,-0.2 0.1,-0.3 v -0.2 c 0,-0.2 0,-0.3 -0.1,-0.3 -0.1,-0.1 -0.2,-0.1 -0.4,-0.1 h -0.9 c -0.4,0 -0.7,-0.1 -0.9,-0.2 -0.3,-0.1 -0.5,-0.3 -0.6,-0.4 -0.1,-0.2 -0.2,-0.3 -0.3,-0.6 -0.1,-0.4 -0.1,-0.8 -0.1,-1.1 z m 6,4.8 v -7.3 h 3.3 c 0.7,0 1.3,0.2 1.7,0.5 0.4,0.4 0.6,1 0.6,1.8 0,0.8 -0.1,1.4 -0.4,1.7 -0.1,0.1 -0.2,0.3 -0.3,0.3 -0.1,0 -0.2,0.1 -0.4,0.2 l 1.3,2.8 h -2.2 l -0.9,-2.6 -0.6,-0.1 v 2.7 z m 1.9,-4.2 h 1.1 c 0.2,0 0.4,-0.1 0.4,-0.2 0.1,-0.1 0.1,-0.3 0.1,-0.6 0,-0.3 0,-0.5 -0.1,-0.6 -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 h -1.1 z m 4,2.1 v -1.5 h 3.1 v 1.5 z m 3.6,-3.5 v -1.7 h 4.8 l 0.5,0.8 -2.3,6.5 h -2.1 l 2,-5.6 z m 8.8,-1.7 v 7.3 h -1.9 v -5.5 l -1.2,0.2 v -1.2 l 1.2,-0.8 z"/>
+            </g>
+          </g>
+          <circle id="Oval-10" class="st7" cx="135.39999" cy="97" r="19" style="fill:#ffffff;fill-opacity:0.2;stroke:#ffffff;stroke-width:2"/>
+          <path id="Path-9" class="st8" d="m 116.9,93 c 0,0 -4.9,11.4 3.6,32.9 8.5,21.5 6.6,31.3 6.6,31.3" style="fill:none;stroke:#ffffff;stroke-width:2"/>
+        </g>
+      </g>
+    </g>
+  </g>
+  <title id="title3782">oidc</title>
+  <g id="Layer_2" data-name="Layer 2" transform="matrix(2, 0, 0, 2, 72.529999, -250)">
+    <rect id="Rectangle-11" class="cls-1" width="50" height="50" style="fill:none" x="13.735" y="125"/>
+    <polygon id="polygon-1" class="cls-2" points="37.065 135.695 37.065 167.025 42.625 164.405 42.625 132.975" style="fill:#f48018"/>
+    <path id="Shape-2" data-name="Shape" class="cls-3" d="M 25.915 155.105 C 25.915 151.105 30.215 147.835 36.075 146.815 L 36.075 143.285 C 27.075 144.365 20.355 149.285 20.355 155.105 C 20.355 161.175 27.615 166.195 37.065 167.025 L 37.065 163.535 C 30.705 162.735 25.915 159.265 25.915 155.105 Z M 46.345 150.525 L 57.115 152.875 L 56.345 144.875 L 53.485 146.485 C 50.453 144.735 47.087 143.641 43.605 143.275 L 43.605 146.805 C 45.751 147.151 47.814 147.898 49.685 149.005 L 49.365 148.815 Z" style="fill:#aeb0b3"/>
+    <polygon id="Shape-4" data-name="Shape" class="cls-2" points="37.065 135.695 37.065 167.025 42.625 164.405 42.625 132.975" style="fill:#f48018"/>
+    <path id="Shape-5" data-name="Shape" class="cls-3" d="M 25.915 155.105 C 25.915 151.105 30.215 147.835 36.075 146.815 L 36.075 143.285 C 27.075 144.365 20.355 149.285 20.355 155.105 C 20.355 161.175 27.615 166.195 37.065 167.025 L 37.065 163.535 C 30.705 162.735 25.915 159.265 25.915 155.105 Z" style="fill:#aeb0b3"/>
+  </g>
 </svg>

--- a/docs/img/dex-callback.svg
+++ b/docs/img/dex-callback.svg
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg viewBox="0 0 275 300" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 325 300" xmlns="http://www.w3.org/2000/svg">
   <style>
     text {
       font: small Verdana, Helvetica, Arial, sans-serif;
@@ -33,28 +33,90 @@
       100% { opacity: 1; }
     }
   </style>
-  <marker id="triangle"
-    viewBox="0 0 10 10"
-    refX="0"
-    refY="5" 
-    markerUnits="strokeWidth"
-    markerWidth="4"
-    markerHeight="3"
-    orient="auto">
-    <path d="M 0 0 L 10 5 L 0 10 z" />
+  <marker id="triangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z"/>
   </marker>
-  <text class="step step1" x="25" y="232.5">GET /callback</text>
-	<line class="step step1" x1="20" y1="237.5" x2="85" y2="237.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step2" x="60" y="150">Forward request</text>
-	<line class="step step2" x1="137.5" y1="180" x2="137.5" y2="120" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step3" x="175" y="150">Generate auth token</text>
-  <line class="step step3" x1="162.5" y1="120" x2="162.5" y2="180" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-	<line class="step step4" x1="85" y1="262.5" x2="20" y2="262.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-  <text class="step step4" x="25" y="267.5" dominant-baseline="hanging">301 /foo</text>
-
-  <image height="100" width="100" x="100" y="0" xlink:href="oidc.svg"><title>OIDC Gatekeeper</title></image>
-  <image height="100" width="100" x="100" y="200" xlink:href="ambassador.svg"><title>Ambassador</title></image>
+  <text class="step step1" x="13.21" y="230.207" style="white-space: pre; font-size: 13px;">GET /callback</text>
+  <line class="step step1" x1="20" y1="237.5" x2="85" y2="237.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step2" x="23.319" y="150.006" style="white-space: pre; font-size: 13px;">Forward request</text>
+  <line class="step step2" x1="137.5" y1="180" x2="137.5" y2="120" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step3" x="175" y="150" style="white-space: pre;">Generate auth token</text>
+  <line class="step step3" x1="162.5" y1="120" x2="162.5" y2="180" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <line class="step step4" x1="85" y1="262.5" x2="20" y2="262.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step4" x="25" y="267.5" dominant-baseline="hanging" style="white-space: pre;">301 /foo</text>
+  <g id="Layer_2" data-name="Layer 2" transform="matrix(2, 0, 0, 2, 72.529999, -250)">
+    <rect id="Rectangle-11" class="cls-1" width="50" height="50" style="fill:none" x="13.735" y="125"/>
+    <polygon id="polygon-1" class="cls-2" points="37.065 135.695 37.065 167.025 42.625 164.405 42.625 132.975" style="fill:#f48018"/>
+    <path id="Shape-2" data-name="Shape" class="cls-3" d="M 25.915 155.105 C 25.915 151.105 30.215 147.835 36.075 146.815 L 36.075 143.285 C 27.075 144.365 20.355 149.285 20.355 155.105 C 20.355 161.175 27.615 166.195 37.065 167.025 L 37.065 163.535 C 30.705 162.735 25.915 159.265 25.915 155.105 Z M 46.345 150.525 L 57.115 152.875 L 56.345 144.875 L 53.485 146.485 C 50.453 144.735 47.087 143.641 43.605 143.275 L 43.605 146.805 C 45.751 147.151 47.814 147.898 49.685 149.005 L 49.365 148.815 Z" style="fill:#aeb0b3"/>
+    <polygon id="Shape-4" data-name="Shape" class="cls-2" points="37.065 135.695 37.065 167.025 42.625 164.405 42.625 132.975" style="fill:#f48018"/>
+    <path id="Shape-5" data-name="Shape" class="cls-3" d="M 25.915 155.105 C 25.915 151.105 30.215 147.835 36.075 146.815 L 36.075 143.285 C 27.075 144.365 20.355 149.285 20.355 155.105 C 20.355 161.175 27.615 166.195 37.065 167.025 L 37.065 163.535 C 30.705 162.735 25.915 159.265 25.915 155.105 Z" style="fill:#aeb0b3"/>
+  </g>
+  <filter filterUnits="objectBoundingBox" height="3.6670001" id="filter-1" width="1.3" x="-0.15000001" y="-1.3330001">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="4" id="feGaussianBlur135"/>
+  </filter>
+  <g id="Page-1" transform="matrix(0.412266, 0, 0, 0.412266, 95.922829, 201.056168)">
+    <g id="Ambassador" transform="translate(-25,-10)">
+      <g id="Group-4" transform="translate(0,4)">
+        <g id="Group-2" transform="translate(12)">
+          <g id="Group-17-Copy-2" transform="translate(0,54)">
+            <g id="Group-16">
+              <g id="Oval-8-Copy-10" class="st0" style="opacity:0.20379998;filter:url(#filter-1);enable-background:new">
+                <ellipse cx="153.39999" cy="187.5" rx="40" ry="4.5" id="ellipse138"/>
+              </g>
+              <g id="Group-12-Copy-8" transform="translate(52,164)">
+                <path id="Line-Copy-18" d="m 83.5,4.2 c -0.7,0 -1.2,0.6 -1.2,1.2 l 0.5,14 c 0,0.7 0.6,1.2 1.2,1.2 l 5.6,-0.2 c 0.7,0 1.2,-0.6 1.2,-1.2 L 90.3,5.2 C 90.3,4.5 89.7,4 89.1,4 Z"/>
+                <path id="Rectangle-7-Copy-15" d="m 70.4,17.4 c 0,-1.3 1.1,-2.4 2.4,-2.4 H 83 c 1.3,0 2.4,1.1 2.4,2.4 v 1.1 c 0,0.6 -0.4,1 -1,1 l -11.6,0.3 c -1.3,0.1 -2.4,-1 -2.4,-2.4 z"/>
+              </g>
+              <g id="Group-12-Copy-10" transform="matrix(-1,0,0,1,117,164)">
+                <path id="Line-Copy-18_1_" d="m -57.4,4.2 c -0.7,0 -1.2,0.6 -1.2,1.2 l 0.5,14 c 0,0.7 0.6,1.2 1.2,1.2 l 5.6,-0.2 c 0.7,0 1.2,-0.6 1.2,-1.2 l -0.5,-14 C -50.6,4.5 -51.2,4 -51.8,4 Z"/>
+                <path id="Rectangle-7-Copy-15_1_" d="m -70.4,17.4 c 0,-1.3 1.1,-2.4 2.4,-2.4 h 10.2 c 1.3,0 2.4,1.1 2.4,2.4 v 1.1 c 0,0.6 -0.4,1 -1,1 L -68,19.8 c -1.4,0.1 -2.4,-1 -2.4,-2.4 z"/>
+              </g>
+              <path id="Combined-Shape" d="m 145.8,3 c 3.4,4.2 12.7,9.7 24.3,13.9 12,4.4 23,6.1 28.1,4.9 7,9.4 10.4,21.6 8.9,35 l -11,92.4 c -1.4,12.1 -12.5,21.9 -24.6,21.9 h -36 c -12.1,0 -23.2,-9.8 -24.6,-21.9 L 99.9,56.8 C 96.4,27.7 116.8,4 145.8,3 Z m 10.8,0 h 2.7 c 12.3,0 23.1,4.1 31.4,10.9 -1,2.5 -9.4,1.7 -18.8,-1.8 C 164.2,9.3 158.1,5.6 156.6,3 Z"/>
+              <g id="Group" transform="translate(42,27)">
+                <g id="Group-3" transform="translate(43)">
+                  <path id="Oval-3-Copy-4" class="st1" d="m 95.2,29.6 c 7.8,-4.5 10.5,-14.5 6,-22.3 -4.5,-7.8 -28.3,16.4 -28.3,16.4 0,0 14.5,10.4 22.3,5.9 z" style="fill:#ffffff"/>
+                  <ellipse id="Oval-3-Copy-5" cx="82.199997" cy="19.299999" rx="5.3000002" ry="5.1999998"/>
+                </g>
+                <g id="Group-3-Copy" transform="matrix(-1,0,0,1,39,0)">
+                  <path id="Oval-3-Copy-4_1_" class="st1" d="m -45.7,29.6 c 7.8,-4.5 10.5,-14.5 6,-22.3 -4.5,-7.8 -28.3,16.4 -28.3,16.4 0,0 14.5,10.4 22.3,5.9 z" style="fill:#ffffff"/>
+                  <ellipse id="Oval-3-Copy-5_1_" cx="-58.700001" cy="19.299999" rx="5.3000002" ry="0"/>
+                </g>
+              </g>
+              <path id="Combined-Shape-Copy-13" d="m 106.9,122.5 -5.7,-10.7 1.8,-0.9 5,9.5 1,-2.1 -4.8,-9.1 1.8,-0.9 4.1,7.8 1,-2.1 -3.9,-7.4 1.8,-0.9 3.3,6.1 4.4,-8.8 c 0,0 -7.1,-17.9 -8.4,-22.2 C 106,73.5 85,76 83.6,88.2 c -1.4,12.3 18.7,43.4 18.7,43.4 z"/>
+              <path id="Combined-Shape-Copy-4" d="m 232.9,65.2 -10.1,6.8 1.1,1.7 8.9,-6 -0.1,2.3 -8.5,5.7 1.1,1.7 7.3,-4.9 -0.1,2.3 -6.9,4.7 1.1,1.7 5.7,-3.9 -0.3,9.8 c 0,0 -14.6,12.4 -17.8,15.6 C 208.9,108.1 191.6,96 196.1,84.5 200.8,73 233.2,55 233.2,55 Z"/>
+              <polygon id="Rectangle-2-Copy-18" class="st1" points="194.3,156.7 114.8,157.6 102.4,69 154,114.7 204.9,66.3 " style="fill:#ffffff"/>
+              <g id="Rectangle-2-Copy-17">
+                <g id="g159">
+                  <polygon id="path-2" class="st2" points="154.6,172.6 145.8,177.4 131.8,179.4 112.8,165 108,126.6 102.6,72.2 155.3,150.8 204.2,74.5 199.7,120 195.6,164.1 179.8,179.4 164.7,178.4 " style="fill:#333333"/>
+                </g>
+                <path class="st3" d="m 108.5,126.5 4.8,38.2 18.6,14.1 13.7,-2 8.9,-4.8 10.3,5.8 14.8,1 15.5,-14.9 4.1,-43.9 4.3,-43.5 -48.2,75.2 -52,-77.6 z" id="path161" style="fill:none;stroke:#000000"/>
+              </g>
+              <path id="Rectangle-4-Copy-7" class="st4" d="m 152.2,59.4 c 0.8,-0.8 2,-0.8 2.8,0 l 9.9,9.9 c 0.8,0.8 0.6,1.8 -0.4,2.3 l -8.6,4.3 c -1,0.5 -2.6,0.5 -3.6,0.1 l -9.6,-4.4 c -1,-0.5 -1.2,-1.5 -0.4,-2.2 z" style="fill:#f5a623"/>
+            </g>
+          </g>
+          <g id="Group_1_" transform="rotate(20,46.247574,262.28303)">
+            <path id="Shape" d="m 115.2,21.5 c 0.1,1.4 0.2,2.9 0.4,4.3 0,2.6 -8.2,4.8 -18.3,4.8 C 87.2,30.6 79,28.5 79,25.8 v 0 c 0.2,-1.4 0.3,-2.8 0.4,-4.3 -7.4,1.4 -12.2,3.7 -12.2,6.3 0,4.3 13.5,7.9 30.1,7.9 16.6,0 30.1,-3.5 30.1,-7.9 -0.1,-2.6 -4.8,-4.9 -12.2,-6.3 z"/>
+            <path id="Shape_1_" class="st5" d="m 116.5,-7.5 c -0.6,2.8 -7.9,5 -19.2,5 -11.4,0 -18.7,-2.2 -19.2,-5 0,0 2.2,17.3 1.4,34 0.8,2.4 8.5,4.2 17.8,4.2 9.3,0 17,-1.9 17.8,-4.2 -0.8,-16.8 1.4,-34 1.4,-34 z" style="fill:#e54733"/>
+            <path id="Shape-Copy" d="m 118.5,-14.2 c -0.6,2.8 -9.9,5 -21.2,5 -11.4,0 -20.7,-2.2 -21.2,-5 0,0 4.2,17.3 3.4,34 0.8,2.4 8.5,4.2 17.8,4.2 9.3,0 17,-1.9 17.8,-4.2 -0.8,-16.7 3.4,-34 3.4,-34 z"/>
+            <path id="Shape_2_" d="m 118.6,-15.5 c 0,0.1 0,0.2 0,0.3 -0.6,2.8 -9.9,5 -21.2,5 -11.4,0 -20.7,-2.2 -21.2,-5 0,-0.1 0,-0.2 0,-0.3 0,-2.9 9.5,-5.3 21.3,-5.3 11.5,0 21.1,2.4 21.1,5.3 z"/>
+          </g>
+          <path id="Path-8-Copy" class="st6" d="m 132.6,139.7 c -0.9,-0.6 -1.6,-0.2 -1.5,0.9 l 2.1,26 c 0.1,1.1 0.9,1.5 1.8,0.9 L 174.7,140 c 0.9,-0.6 1.6,-0.2 1.6,0.9 v 25.3 c 0,1.1 -0.8,1.5 -1.7,0.9 z" style="fill:#e64934;stroke:#000000"/>
+          <g id="Group-2-Copy" transform="translate(81,174)">
+            <circle id="Oval-10-Copy" cx="72.400002" cy="5" r="2"/>
+            <circle id="Oval-10-Copy-2" cx="72.400002" cy="13" r="2"/>
+          </g>
+          <g id="SR-71-Copy-4" transform="rotate(-56,108.8957,180.16374)">
+            <g id="g177">
+              <path id="path-3" class="st2" d="m 133.7,239.1 v -0.6 c 0,-0.6 0.2,-1.1 0.5,-1.4 0.4,-0.3 0.8,-0.5 1.4,-0.5 0.3,0 0.5,0 0.8,0 0.9,0 1.7,0.1 2.3,0.4 v 1.5 c -0.6,-0.1 -1.4,-0.1 -2.4,-0.1 -0.3,0 -0.5,0 -0.6,0.1 -0.1,0 -0.2,0.2 -0.2,0.4 v 0.1 c 0,0.2 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.5,0.1 h 0.9 c 0.8,0 1.3,0.3 1.7,1 0.1,0.3 0.2,0.7 0.2,1.1 v 0.3 c 0,1.5 -0.7,2.2 -2,2.2 -1,0 -1.6,0 -1.9,0 -0.3,0 -0.7,-0.1 -1.2,-0.3 v -1.5 c 0.7,0.1 1.6,0.1 2.6,0.1 0.2,0 0.4,0 0.5,-0.1 0.1,-0.1 0.1,-0.2 0.1,-0.3 v -0.2 c 0,-0.2 0,-0.3 -0.1,-0.3 -0.1,-0.1 -0.2,-0.1 -0.4,-0.1 h -0.9 c -0.4,0 -0.7,-0.1 -0.9,-0.2 -0.3,-0.1 -0.5,-0.3 -0.6,-0.4 -0.1,-0.2 -0.2,-0.3 -0.3,-0.6 -0.1,-0.4 -0.1,-0.8 -0.1,-1.1 z m 6,4.8 v -7.3 h 3.3 c 0.7,0 1.3,0.2 1.7,0.5 0.4,0.4 0.6,1 0.6,1.8 0,0.8 -0.1,1.4 -0.4,1.7 -0.1,0.1 -0.2,0.3 -0.3,0.3 -0.1,0 -0.2,0.1 -0.4,0.2 l 1.3,2.8 h -2.2 l -0.9,-2.6 -0.6,-0.1 v 2.7 z m 1.9,-4.2 h 1.1 c 0.2,0 0.4,-0.1 0.4,-0.2 0.1,-0.1 0.1,-0.3 0.1,-0.6 0,-0.3 0,-0.5 -0.1,-0.6 -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 h -1.1 z m 4,2.1 v -1.5 h 3.1 v 1.5 z m 3.6,-3.5 v -1.7 h 4.8 l 0.5,0.8 -2.3,6.5 h -2.1 l 2,-5.6 z m 8.8,-1.7 v 7.3 h -1.9 v -5.5 l -1.2,0.2 v -1.2 l 1.2,-0.8 z" style="fill:#333333"/>
+            </g>
+            <g id="g180">
+              <path id="path-3_1_" d="m 133.7,239.1 v -0.6 c 0,-0.6 0.2,-1.1 0.5,-1.4 0.4,-0.3 0.8,-0.5 1.4,-0.5 0.3,0 0.5,0 0.8,0 0.9,0 1.7,0.1 2.3,0.4 v 1.5 c -0.6,-0.1 -1.4,-0.1 -2.4,-0.1 -0.3,0 -0.5,0 -0.6,0.1 -0.1,0 -0.2,0.2 -0.2,0.4 v 0.1 c 0,0.2 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.5,0.1 h 0.9 c 0.8,0 1.3,0.3 1.7,1 0.1,0.3 0.2,0.7 0.2,1.1 v 0.3 c 0,1.5 -0.7,2.2 -2,2.2 -1,0 -1.6,0 -1.9,0 -0.3,0 -0.7,-0.1 -1.2,-0.3 v -1.5 c 0.7,0.1 1.6,0.1 2.6,0.1 0.2,0 0.4,0 0.5,-0.1 0.1,-0.1 0.1,-0.2 0.1,-0.3 v -0.2 c 0,-0.2 0,-0.3 -0.1,-0.3 -0.1,-0.1 -0.2,-0.1 -0.4,-0.1 h -0.9 c -0.4,0 -0.7,-0.1 -0.9,-0.2 -0.3,-0.1 -0.5,-0.3 -0.6,-0.4 -0.1,-0.2 -0.2,-0.3 -0.3,-0.6 -0.1,-0.4 -0.1,-0.8 -0.1,-1.1 z m 6,4.8 v -7.3 h 3.3 c 0.7,0 1.3,0.2 1.7,0.5 0.4,0.4 0.6,1 0.6,1.8 0,0.8 -0.1,1.4 -0.4,1.7 -0.1,0.1 -0.2,0.3 -0.3,0.3 -0.1,0 -0.2,0.1 -0.4,0.2 l 1.3,2.8 h -2.2 l -0.9,-2.6 -0.6,-0.1 v 2.7 z m 1.9,-4.2 h 1.1 c 0.2,0 0.4,-0.1 0.4,-0.2 0.1,-0.1 0.1,-0.3 0.1,-0.6 0,-0.3 0,-0.5 -0.1,-0.6 -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 h -1.1 z m 4,2.1 v -1.5 h 3.1 v 1.5 z m 3.6,-3.5 v -1.7 h 4.8 l 0.5,0.8 -2.3,6.5 h -2.1 l 2,-5.6 z m 8.8,-1.7 v 7.3 h -1.9 v -5.5 l -1.2,0.2 v -1.2 l 1.2,-0.8 z"/>
+            </g>
+          </g>
+          <circle id="Oval-10" class="st7" cx="135.39999" cy="97" r="19" style="fill:#ffffff;fill-opacity:0.2;stroke:#ffffff;stroke-width:2"/>
+          <path id="Path-9" class="st8" d="m 116.9,93 c 0,0 -4.9,11.4 3.6,32.9 8.5,21.5 6.6,31.3 6.6,31.3" style="fill:none;stroke:#ffffff;stroke-width:2"/>
+        </g>
+      </g>
+    </g>
+  </g>
 </svg>

--- a/docs/img/dex-login.svg
+++ b/docs/img/dex-login.svg
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg viewBox="0 0 300 500" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 325 500" xmlns="http://www.w3.org/2000/svg">
   <style>
     text {
       font: smaller Verdana, Helvetica, Arial, sans-serif;
@@ -48,35 +48,96 @@
       91.66% { opacity: 1; }
     }
   </style>
-  <marker id="triangle"
-    viewBox="0 0 10 10"
-    refX="0"
-    refY="5" 
-    markerUnits="strokeWidth"
-    markerWidth="4"
-    markerHeight="3"
-    orient="auto">
-    <path d="M 0 0 L 10 5 L 0 10 z" />
+  <marker id="triangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z"/>
   </marker>
-  <text class="step step1" x="30" y="67.5" dominant-baseline="hanging">GET /foo</text>
-	<line class="step step1" x1="20" y1="62.5" x2="80" y2="62.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-	
-  <text class="step step2" x="40" y="160">Follow redirect</text>
-  <line class="step step2" x1="137.5" y1="120" x2="137.5" y2="180" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step3" x="20" y="360">Submit credentials</text>
-	<line class="step step3" x1="137.5" y1="320" x2="137.5" y2="380" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step4" x="180" y="360">Confirm credentials</text>
-	<line class="step step4" x1="162.5" y1="380" x2="162.5" y2="320" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step5" x="180" y="160">Redirect to callback</text>
-	<line class="step step5" x1="162.5" y1="180" x2="162.5" y2="120" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step6" x="30" y="32.5">301 /callback</text>
-  <line class="step step6" x1="80" y1="37.5" x2="20" y2="37.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <image height="100" width="100" x="100" y="0" xlink:href="ambassador.svg"><title>Ambassador</title></image>
-  <image height="100" width="100" x="100" y="200" xlink:href="dex.svg"><title>Dex IDP</title></image>
-  <image height="100" width="100" x="100" y="400" xlink:href="cloud.svg"><title>External Service</title></image>
+  <text class="step step1" x="30" y="67.5" dominant-baseline="hanging" style="white-space: pre;">GET /foo</text>
+  <line class="step step1" x1="20" y1="62.5" x2="80" y2="62.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step2" x="40" y="160" style="white-space: pre;">Follow redirect</text>
+  <line class="step step2" x1="137.5" y1="120" x2="137.5" y2="180" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step3" x="20" y="360" style="white-space: pre;">Submit credentials</text>
+  <line class="step step3" x1="137.5" y1="320" x2="137.5" y2="380" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step4" x="180" y="360" style="white-space: pre;">Confirm credentials</text>
+  <line class="step step4" x1="162.5" y1="380" x2="162.5" y2="320" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step5" x="180" y="160" style="white-space: pre;">Redirect to callback</text>
+  <line class="step step5" x1="162.5" y1="180" x2="162.5" y2="120" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step6" x="30" y="32.5" style="white-space: pre;">301 /callback</text>
+  <line class="step step6" x1="80" y1="37.5" x2="20" y2="37.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <filter filterUnits="objectBoundingBox" height="3.6670001" id="filter-1" width="1.3" x="-0.15000001" y="-1.3330001">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="4" id="feGaussianBlur135"/>
+  </filter>
+  <g id="Page-1" transform="matrix(0.412266, 0, 0, 0.412266, 95.922829, 1.056164)">
+    <g id="Ambassador" transform="translate(-25,-10)">
+      <g id="Group-4" transform="translate(0,4)">
+        <g id="Group-2" transform="translate(12)">
+          <g id="Group-17-Copy-2" transform="translate(0,54)">
+            <g id="Group-16">
+              <g id="Oval-8-Copy-10" class="st0" style="opacity:0.20379998;filter:url(#filter-1);enable-background:new">
+                <ellipse cx="153.39999" cy="187.5" rx="40" ry="4.5" id="ellipse138"/>
+              </g>
+              <g id="Group-12-Copy-8" transform="translate(52,164)">
+                <path id="Line-Copy-18" d="m 83.5,4.2 c -0.7,0 -1.2,0.6 -1.2,1.2 l 0.5,14 c 0,0.7 0.6,1.2 1.2,1.2 l 5.6,-0.2 c 0.7,0 1.2,-0.6 1.2,-1.2 L 90.3,5.2 C 90.3,4.5 89.7,4 89.1,4 Z"/>
+                <path id="Rectangle-7-Copy-15" d="m 70.4,17.4 c 0,-1.3 1.1,-2.4 2.4,-2.4 H 83 c 1.3,0 2.4,1.1 2.4,2.4 v 1.1 c 0,0.6 -0.4,1 -1,1 l -11.6,0.3 c -1.3,0.1 -2.4,-1 -2.4,-2.4 z"/>
+              </g>
+              <g id="Group-12-Copy-10" transform="matrix(-1,0,0,1,117,164)">
+                <path id="Line-Copy-18_1_" d="m -57.4,4.2 c -0.7,0 -1.2,0.6 -1.2,1.2 l 0.5,14 c 0,0.7 0.6,1.2 1.2,1.2 l 5.6,-0.2 c 0.7,0 1.2,-0.6 1.2,-1.2 l -0.5,-14 C -50.6,4.5 -51.2,4 -51.8,4 Z"/>
+                <path id="Rectangle-7-Copy-15_1_" d="m -70.4,17.4 c 0,-1.3 1.1,-2.4 2.4,-2.4 h 10.2 c 1.3,0 2.4,1.1 2.4,2.4 v 1.1 c 0,0.6 -0.4,1 -1,1 L -68,19.8 c -1.4,0.1 -2.4,-1 -2.4,-2.4 z"/>
+              </g>
+              <path id="Combined-Shape" d="m 145.8,3 c 3.4,4.2 12.7,9.7 24.3,13.9 12,4.4 23,6.1 28.1,4.9 7,9.4 10.4,21.6 8.9,35 l -11,92.4 c -1.4,12.1 -12.5,21.9 -24.6,21.9 h -36 c -12.1,0 -23.2,-9.8 -24.6,-21.9 L 99.9,56.8 C 96.4,27.7 116.8,4 145.8,3 Z m 10.8,0 h 2.7 c 12.3,0 23.1,4.1 31.4,10.9 -1,2.5 -9.4,1.7 -18.8,-1.8 C 164.2,9.3 158.1,5.6 156.6,3 Z"/>
+              <g id="Group" transform="translate(42,27)">
+                <g id="Group-3" transform="translate(43)">
+                  <path id="Oval-3-Copy-4" class="st1" d="m 95.2,29.6 c 7.8,-4.5 10.5,-14.5 6,-22.3 -4.5,-7.8 -28.3,16.4 -28.3,16.4 0,0 14.5,10.4 22.3,5.9 z" style="fill:#ffffff"/>
+                  <ellipse id="Oval-3-Copy-5" cx="82.199997" cy="19.299999" rx="5.3000002" ry="5.1999998"/>
+                </g>
+                <g id="Group-3-Copy" transform="matrix(-1,0,0,1,39,0)">
+                  <path id="Oval-3-Copy-4_1_" class="st1" d="m -45.7,29.6 c 7.8,-4.5 10.5,-14.5 6,-22.3 -4.5,-7.8 -28.3,16.4 -28.3,16.4 0,0 14.5,10.4 22.3,5.9 z" style="fill:#ffffff"/>
+                  <ellipse id="Oval-3-Copy-5_1_" cx="-58.700001" cy="19.299999" rx="5.3000002" ry="0"/>
+                </g>
+              </g>
+              <path id="Combined-Shape-Copy-13" d="m 106.9,122.5 -5.7,-10.7 1.8,-0.9 5,9.5 1,-2.1 -4.8,-9.1 1.8,-0.9 4.1,7.8 1,-2.1 -3.9,-7.4 1.8,-0.9 3.3,6.1 4.4,-8.8 c 0,0 -7.1,-17.9 -8.4,-22.2 C 106,73.5 85,76 83.6,88.2 c -1.4,12.3 18.7,43.4 18.7,43.4 z"/>
+              <path id="Combined-Shape-Copy-4" d="m 232.9,65.2 -10.1,6.8 1.1,1.7 8.9,-6 -0.1,2.3 -8.5,5.7 1.1,1.7 7.3,-4.9 -0.1,2.3 -6.9,4.7 1.1,1.7 5.7,-3.9 -0.3,9.8 c 0,0 -14.6,12.4 -17.8,15.6 C 208.9,108.1 191.6,96 196.1,84.5 200.8,73 233.2,55 233.2,55 Z"/>
+              <polygon id="Rectangle-2-Copy-18" class="st1" points="194.3,156.7 114.8,157.6 102.4,69 154,114.7 204.9,66.3 " style="fill:#ffffff"/>
+              <g id="Rectangle-2-Copy-17">
+                <g id="g159">
+                  <polygon id="path-2" class="st2" points="154.6,172.6 145.8,177.4 131.8,179.4 112.8,165 108,126.6 102.6,72.2 155.3,150.8 204.2,74.5 199.7,120 195.6,164.1 179.8,179.4 164.7,178.4 " style="fill:#333333"/>
+                </g>
+                <path class="st3" d="m 108.5,126.5 4.8,38.2 18.6,14.1 13.7,-2 8.9,-4.8 10.3,5.8 14.8,1 15.5,-14.9 4.1,-43.9 4.3,-43.5 -48.2,75.2 -52,-77.6 z" id="path161" style="fill:none;stroke:#000000"/>
+              </g>
+              <path id="Rectangle-4-Copy-7" class="st4" d="m 152.2,59.4 c 0.8,-0.8 2,-0.8 2.8,0 l 9.9,9.9 c 0.8,0.8 0.6,1.8 -0.4,2.3 l -8.6,4.3 c -1,0.5 -2.6,0.5 -3.6,0.1 l -9.6,-4.4 c -1,-0.5 -1.2,-1.5 -0.4,-2.2 z" style="fill:#f5a623"/>
+            </g>
+          </g>
+          <g id="Group_1_" transform="rotate(20,46.247574,262.28303)">
+            <path id="Shape" d="m 115.2,21.5 c 0.1,1.4 0.2,2.9 0.4,4.3 0,2.6 -8.2,4.8 -18.3,4.8 C 87.2,30.6 79,28.5 79,25.8 v 0 c 0.2,-1.4 0.3,-2.8 0.4,-4.3 -7.4,1.4 -12.2,3.7 -12.2,6.3 0,4.3 13.5,7.9 30.1,7.9 16.6,0 30.1,-3.5 30.1,-7.9 -0.1,-2.6 -4.8,-4.9 -12.2,-6.3 z"/>
+            <path id="Shape_1_" class="st5" d="m 116.5,-7.5 c -0.6,2.8 -7.9,5 -19.2,5 -11.4,0 -18.7,-2.2 -19.2,-5 0,0 2.2,17.3 1.4,34 0.8,2.4 8.5,4.2 17.8,4.2 9.3,0 17,-1.9 17.8,-4.2 -0.8,-16.8 1.4,-34 1.4,-34 z" style="fill:#e54733"/>
+            <path id="Shape-Copy" d="m 118.5,-14.2 c -0.6,2.8 -9.9,5 -21.2,5 -11.4,0 -20.7,-2.2 -21.2,-5 0,0 4.2,17.3 3.4,34 0.8,2.4 8.5,4.2 17.8,4.2 9.3,0 17,-1.9 17.8,-4.2 -0.8,-16.7 3.4,-34 3.4,-34 z"/>
+            <path id="Shape_2_" d="m 118.6,-15.5 c 0,0.1 0,0.2 0,0.3 -0.6,2.8 -9.9,5 -21.2,5 -11.4,0 -20.7,-2.2 -21.2,-5 0,-0.1 0,-0.2 0,-0.3 0,-2.9 9.5,-5.3 21.3,-5.3 11.5,0 21.1,2.4 21.1,5.3 z"/>
+          </g>
+          <path id="Path-8-Copy" class="st6" d="m 132.6,139.7 c -0.9,-0.6 -1.6,-0.2 -1.5,0.9 l 2.1,26 c 0.1,1.1 0.9,1.5 1.8,0.9 L 174.7,140 c 0.9,-0.6 1.6,-0.2 1.6,0.9 v 25.3 c 0,1.1 -0.8,1.5 -1.7,0.9 z" style="fill:#e64934;stroke:#000000"/>
+          <g id="Group-2-Copy" transform="translate(81,174)">
+            <circle id="Oval-10-Copy" cx="72.400002" cy="5" r="2"/>
+            <circle id="Oval-10-Copy-2" cx="72.400002" cy="13" r="2"/>
+          </g>
+          <g id="SR-71-Copy-4" transform="rotate(-56,108.8957,180.16374)">
+            <g id="g177">
+              <path id="path-3" class="st2" d="m 133.7,239.1 v -0.6 c 0,-0.6 0.2,-1.1 0.5,-1.4 0.4,-0.3 0.8,-0.5 1.4,-0.5 0.3,0 0.5,0 0.8,0 0.9,0 1.7,0.1 2.3,0.4 v 1.5 c -0.6,-0.1 -1.4,-0.1 -2.4,-0.1 -0.3,0 -0.5,0 -0.6,0.1 -0.1,0 -0.2,0.2 -0.2,0.4 v 0.1 c 0,0.2 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.5,0.1 h 0.9 c 0.8,0 1.3,0.3 1.7,1 0.1,0.3 0.2,0.7 0.2,1.1 v 0.3 c 0,1.5 -0.7,2.2 -2,2.2 -1,0 -1.6,0 -1.9,0 -0.3,0 -0.7,-0.1 -1.2,-0.3 v -1.5 c 0.7,0.1 1.6,0.1 2.6,0.1 0.2,0 0.4,0 0.5,-0.1 0.1,-0.1 0.1,-0.2 0.1,-0.3 v -0.2 c 0,-0.2 0,-0.3 -0.1,-0.3 -0.1,-0.1 -0.2,-0.1 -0.4,-0.1 h -0.9 c -0.4,0 -0.7,-0.1 -0.9,-0.2 -0.3,-0.1 -0.5,-0.3 -0.6,-0.4 -0.1,-0.2 -0.2,-0.3 -0.3,-0.6 -0.1,-0.4 -0.1,-0.8 -0.1,-1.1 z m 6,4.8 v -7.3 h 3.3 c 0.7,0 1.3,0.2 1.7,0.5 0.4,0.4 0.6,1 0.6,1.8 0,0.8 -0.1,1.4 -0.4,1.7 -0.1,0.1 -0.2,0.3 -0.3,0.3 -0.1,0 -0.2,0.1 -0.4,0.2 l 1.3,2.8 h -2.2 l -0.9,-2.6 -0.6,-0.1 v 2.7 z m 1.9,-4.2 h 1.1 c 0.2,0 0.4,-0.1 0.4,-0.2 0.1,-0.1 0.1,-0.3 0.1,-0.6 0,-0.3 0,-0.5 -0.1,-0.6 -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 h -1.1 z m 4,2.1 v -1.5 h 3.1 v 1.5 z m 3.6,-3.5 v -1.7 h 4.8 l 0.5,0.8 -2.3,6.5 h -2.1 l 2,-5.6 z m 8.8,-1.7 v 7.3 h -1.9 v -5.5 l -1.2,0.2 v -1.2 l 1.2,-0.8 z" style="fill:#333333"/>
+            </g>
+            <g id="g180">
+              <path id="path-3_1_" d="m 133.7,239.1 v -0.6 c 0,-0.6 0.2,-1.1 0.5,-1.4 0.4,-0.3 0.8,-0.5 1.4,-0.5 0.3,0 0.5,0 0.8,0 0.9,0 1.7,0.1 2.3,0.4 v 1.5 c -0.6,-0.1 -1.4,-0.1 -2.4,-0.1 -0.3,0 -0.5,0 -0.6,0.1 -0.1,0 -0.2,0.2 -0.2,0.4 v 0.1 c 0,0.2 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.5,0.1 h 0.9 c 0.8,0 1.3,0.3 1.7,1 0.1,0.3 0.2,0.7 0.2,1.1 v 0.3 c 0,1.5 -0.7,2.2 -2,2.2 -1,0 -1.6,0 -1.9,0 -0.3,0 -0.7,-0.1 -1.2,-0.3 v -1.5 c 0.7,0.1 1.6,0.1 2.6,0.1 0.2,0 0.4,0 0.5,-0.1 0.1,-0.1 0.1,-0.2 0.1,-0.3 v -0.2 c 0,-0.2 0,-0.3 -0.1,-0.3 -0.1,-0.1 -0.2,-0.1 -0.4,-0.1 h -0.9 c -0.4,0 -0.7,-0.1 -0.9,-0.2 -0.3,-0.1 -0.5,-0.3 -0.6,-0.4 -0.1,-0.2 -0.2,-0.3 -0.3,-0.6 -0.1,-0.4 -0.1,-0.8 -0.1,-1.1 z m 6,4.8 v -7.3 h 3.3 c 0.7,0 1.3,0.2 1.7,0.5 0.4,0.4 0.6,1 0.6,1.8 0,0.8 -0.1,1.4 -0.4,1.7 -0.1,0.1 -0.2,0.3 -0.3,0.3 -0.1,0 -0.2,0.1 -0.4,0.2 l 1.3,2.8 h -2.2 l -0.9,-2.6 -0.6,-0.1 v 2.7 z m 1.9,-4.2 h 1.1 c 0.2,0 0.4,-0.1 0.4,-0.2 0.1,-0.1 0.1,-0.3 0.1,-0.6 0,-0.3 0,-0.5 -0.1,-0.6 -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 h -1.1 z m 4,2.1 v -1.5 h 3.1 v 1.5 z m 3.6,-3.5 v -1.7 h 4.8 l 0.5,0.8 -2.3,6.5 h -2.1 l 2,-5.6 z m 8.8,-1.7 v 7.3 h -1.9 v -5.5 l -1.2,0.2 v -1.2 l 1.2,-0.8 z"/>
+            </g>
+          </g>
+          <circle id="Oval-10" class="st7" cx="135.39999" cy="97" r="19" style="fill:#ffffff;fill-opacity:0.2;stroke:#ffffff;stroke-width:2"/>
+          <path id="Path-9" class="st8" d="m 116.9,93 c 0,0 -4.9,11.4 3.6,32.9 8.5,21.5 6.6,31.3 6.6,31.3" style="fill:none;stroke:#ffffff;stroke-width:2"/>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g transform="matrix(0.979608, 0, 0, 0.979608, 95.216232, 196.600754)">
+    <path fill="#449FD8" d="M88.345,51.574c7.588-3.55,12.764-10.49,14.175-18.53C96.396,19.395,84.663,9.054,70.094,4.851 c4.923,7.133,7.272,15.583,6.771,24.17C83.311,34.466,87.716,42.55,88.345,51.574z M27.27,38.542 c-8.207-1.045-16.333,1.973-21.858,8.054C3.23,61.683,7.869,76.84,18.099,88.158c-0.527-8.64,1.856-17.306,6.831-24.483 C22.19,55.048,23.32,45.944,27.27,38.542z M33.01,76.928c-2.997,8.079-1.755,17.193,3.642,24.215 c12.155,4.943,26.051,5.146,38.643-0.035c-7.818-2.516-14.886-7.518-19.887-14.731C47.233,86.23,39.124,83.032,33.01,76.928z M63.122,22.202C61.615,14.044,56.069,6.819,47.892,3.47C33.778,5.711,20.745,13.966,12.76,26.631 c8.115-2.487,16.74-2.178,24.529,0.639C44.816,22.008,54.043,20.144,63.122,22.202z M85.891,66.457 c-3.086,7.399-8.722,13.188-15.678,16.61c6.194,5.604,14.805,7.758,22.852,5.834c9.054-9.587,13.884-22.198,13.9-35.009 C101.549,60.198,94.131,64.67,85.891,66.457z"/>
+    <g>
+      <circle fill="#F04D5C" cx="56.035" cy="53.892" r="15.972"/>
+    </g>
+  </g>
+  <g id="_x2601__xFE0F__1_" transform="matrix(1.666667, 0, 0, 1.666667, 90, 371.333313)">
+    <path fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d=" M15.9,30.3c0,0.4-0.4,0.8-0.8,0.8C10,31.6,6,36.7,6,42.9c0,6.6,4.5,11.9,10.2,11.9h38.7C61,54.8,66,49.1,66,42.2 c0-6.6-4.6-12.1-10.4-12.5c-0.4,0-0.8-0.3-0.9-0.8c-1.3-6.7-7.3-11.7-14.3-11.7c-4.6,0-8.7,2.1-11.3,5.4C28.8,23,28.3,23.1,28,23 c-1-0.4-2.1-0.6-3.3-0.6C20.1,22.3,16.3,25.8,15.9,30.3z"/>
+  </g>
 </svg>

--- a/docs/img/dex-unauthenticated.svg
+++ b/docs/img/dex-unauthenticated.svg
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg viewBox="0 0 275 300" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 325 300" xmlns="http://www.w3.org/2000/svg">
   <style>
     text {
       font: small Verdana, Helvetica, Arial, sans-serif;
@@ -33,28 +33,90 @@
       100% { opacity: 1; }
     }
   </style>
-  <marker id="triangle"
-    viewBox="0 0 10 10"
-    refX="0"
-    refY="5" 
-    markerUnits="strokeWidth"
-    markerWidth="4"
-    markerHeight="3"
-    orient="auto">
-    <path d="M 0 0 L 10 5 L 0 10 z" />
+  <marker id="triangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z"/>
   </marker>
-  <text class="step step1" x="25" y="232.5">GET /foo</text>
-	<line class="step step1" x1="20" y1="237.5" x2="85" y2="237.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step2" x="60" y="150">Authorized?</text>
-	<line class="step step2" x1="137.5" y1="180" x2="137.5" y2="120" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-  <text class="step step3" x="175" y="150">No. Redirect to Dex</text>
-  <line class="step step3" x1="162.5" y1="120" x2="162.5" y2="180" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-
-	<line class="step step4" x1="85" y1="262.5" x2="20" y2="262.5" marker-end="url(#triangle)" stroke="black" stroke-width="3" />
-  <text class="step step4" x="25" y="267.5" dominant-baseline="hanging">301 /dex</text>
-
-  <image height="100" width="100" x="100" y="0" xlink:href="oidc.svg"><title>OIDC Gatekeeper</title></image>
-  <image height="100" width="100" x="100" y="200" xlink:href="ambassador.svg"><title>Ambassador</title></image>
+  <text class="step step1" x="25" y="232.5" style="white-space: pre;">GET /foo</text>
+  <line class="step step1" x1="20" y1="237.5" x2="85" y2="237.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step2" x="60" y="150" style="white-space: pre;">Authorized?</text>
+  <line class="step step2" x1="137.5" y1="180" x2="137.5" y2="120" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step3" x="175" y="150" style="white-space: pre;">No. Redirect to Dex</text>
+  <line class="step step3" x1="162.5" y1="120" x2="162.5" y2="180" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <line class="step step4" x1="85" y1="262.5" x2="20" y2="262.5" marker-end="url(#triangle)" stroke="black" stroke-width="3"/>
+  <text class="step step4" x="25" y="267.5" dominant-baseline="hanging" style="white-space: pre;">301 /dex</text>
+  <g id="Layer_2" data-name="Layer 2" transform="matrix(2, 0, 0, 2, 72.529999, -250)">
+    <rect id="Rectangle-11" class="cls-1" width="50" height="50" style="fill:none" x="13.735" y="125"/>
+    <polygon id="polygon-1" class="cls-2" points="37.065 135.695 37.065 167.025 42.625 164.405 42.625 132.975" style="fill:#f48018"/>
+    <path id="Shape-2" data-name="Shape" class="cls-3" d="M 25.915 155.105 C 25.915 151.105 30.215 147.835 36.075 146.815 L 36.075 143.285 C 27.075 144.365 20.355 149.285 20.355 155.105 C 20.355 161.175 27.615 166.195 37.065 167.025 L 37.065 163.535 C 30.705 162.735 25.915 159.265 25.915 155.105 Z M 46.345 150.525 L 57.115 152.875 L 56.345 144.875 L 53.485 146.485 C 50.453 144.735 47.087 143.641 43.605 143.275 L 43.605 146.805 C 45.751 147.151 47.814 147.898 49.685 149.005 L 49.365 148.815 Z" style="fill:#aeb0b3"/>
+    <polygon id="Shape-4" data-name="Shape" class="cls-2" points="37.065 135.695 37.065 167.025 42.625 164.405 42.625 132.975" style="fill:#f48018"/>
+    <path id="Shape-5" data-name="Shape" class="cls-3" d="M 25.915 155.105 C 25.915 151.105 30.215 147.835 36.075 146.815 L 36.075 143.285 C 27.075 144.365 20.355 149.285 20.355 155.105 C 20.355 161.175 27.615 166.195 37.065 167.025 L 37.065 163.535 C 30.705 162.735 25.915 159.265 25.915 155.105 Z" style="fill:#aeb0b3"/>
+  </g>
+  <filter filterUnits="objectBoundingBox" height="3.6670001" id="filter-1" width="1.3" x="-0.15000001" y="-1.3330001">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="4" id="feGaussianBlur135"/>
+  </filter>
+  <g id="Page-1" transform="matrix(0.412266, 0, 0, 0.412266, 95.922829, 201.056168)">
+    <g id="Ambassador" transform="translate(-25,-10)">
+      <g id="Group-4" transform="translate(0,4)">
+        <g id="Group-2" transform="translate(12)">
+          <g id="Group-17-Copy-2" transform="translate(0,54)">
+            <g id="Group-16">
+              <g id="Oval-8-Copy-10" class="st0" style="opacity:0.20379998;filter:url(#filter-1);enable-background:new">
+                <ellipse cx="153.39999" cy="187.5" rx="40" ry="4.5" id="ellipse138"/>
+              </g>
+              <g id="Group-12-Copy-8" transform="translate(52,164)">
+                <path id="Line-Copy-18" d="m 83.5,4.2 c -0.7,0 -1.2,0.6 -1.2,1.2 l 0.5,14 c 0,0.7 0.6,1.2 1.2,1.2 l 5.6,-0.2 c 0.7,0 1.2,-0.6 1.2,-1.2 L 90.3,5.2 C 90.3,4.5 89.7,4 89.1,4 Z"/>
+                <path id="Rectangle-7-Copy-15" d="m 70.4,17.4 c 0,-1.3 1.1,-2.4 2.4,-2.4 H 83 c 1.3,0 2.4,1.1 2.4,2.4 v 1.1 c 0,0.6 -0.4,1 -1,1 l -11.6,0.3 c -1.3,0.1 -2.4,-1 -2.4,-2.4 z"/>
+              </g>
+              <g id="Group-12-Copy-10" transform="matrix(-1,0,0,1,117,164)">
+                <path id="Line-Copy-18_1_" d="m -57.4,4.2 c -0.7,0 -1.2,0.6 -1.2,1.2 l 0.5,14 c 0,0.7 0.6,1.2 1.2,1.2 l 5.6,-0.2 c 0.7,0 1.2,-0.6 1.2,-1.2 l -0.5,-14 C -50.6,4.5 -51.2,4 -51.8,4 Z"/>
+                <path id="Rectangle-7-Copy-15_1_" d="m -70.4,17.4 c 0,-1.3 1.1,-2.4 2.4,-2.4 h 10.2 c 1.3,0 2.4,1.1 2.4,2.4 v 1.1 c 0,0.6 -0.4,1 -1,1 L -68,19.8 c -1.4,0.1 -2.4,-1 -2.4,-2.4 z"/>
+              </g>
+              <path id="Combined-Shape" d="m 145.8,3 c 3.4,4.2 12.7,9.7 24.3,13.9 12,4.4 23,6.1 28.1,4.9 7,9.4 10.4,21.6 8.9,35 l -11,92.4 c -1.4,12.1 -12.5,21.9 -24.6,21.9 h -36 c -12.1,0 -23.2,-9.8 -24.6,-21.9 L 99.9,56.8 C 96.4,27.7 116.8,4 145.8,3 Z m 10.8,0 h 2.7 c 12.3,0 23.1,4.1 31.4,10.9 -1,2.5 -9.4,1.7 -18.8,-1.8 C 164.2,9.3 158.1,5.6 156.6,3 Z"/>
+              <g id="Group" transform="translate(42,27)">
+                <g id="Group-3" transform="translate(43)">
+                  <path id="Oval-3-Copy-4" class="st1" d="m 95.2,29.6 c 7.8,-4.5 10.5,-14.5 6,-22.3 -4.5,-7.8 -28.3,16.4 -28.3,16.4 0,0 14.5,10.4 22.3,5.9 z" style="fill:#ffffff"/>
+                  <ellipse id="Oval-3-Copy-5" cx="82.199997" cy="19.299999" rx="5.3000002" ry="5.1999998"/>
+                </g>
+                <g id="Group-3-Copy" transform="matrix(-1,0,0,1,39,0)">
+                  <path id="Oval-3-Copy-4_1_" class="st1" d="m -45.7,29.6 c 7.8,-4.5 10.5,-14.5 6,-22.3 -4.5,-7.8 -28.3,16.4 -28.3,16.4 0,0 14.5,10.4 22.3,5.9 z" style="fill:#ffffff"/>
+                  <ellipse id="Oval-3-Copy-5_1_" cx="-58.700001" cy="19.299999" rx="5.3000002" ry="0"/>
+                </g>
+              </g>
+              <path id="Combined-Shape-Copy-13" d="m 106.9,122.5 -5.7,-10.7 1.8,-0.9 5,9.5 1,-2.1 -4.8,-9.1 1.8,-0.9 4.1,7.8 1,-2.1 -3.9,-7.4 1.8,-0.9 3.3,6.1 4.4,-8.8 c 0,0 -7.1,-17.9 -8.4,-22.2 C 106,73.5 85,76 83.6,88.2 c -1.4,12.3 18.7,43.4 18.7,43.4 z"/>
+              <path id="Combined-Shape-Copy-4" d="m 232.9,65.2 -10.1,6.8 1.1,1.7 8.9,-6 -0.1,2.3 -8.5,5.7 1.1,1.7 7.3,-4.9 -0.1,2.3 -6.9,4.7 1.1,1.7 5.7,-3.9 -0.3,9.8 c 0,0 -14.6,12.4 -17.8,15.6 C 208.9,108.1 191.6,96 196.1,84.5 200.8,73 233.2,55 233.2,55 Z"/>
+              <polygon id="Rectangle-2-Copy-18" class="st1" points="194.3,156.7 114.8,157.6 102.4,69 154,114.7 204.9,66.3 " style="fill:#ffffff"/>
+              <g id="Rectangle-2-Copy-17">
+                <g id="g159">
+                  <polygon id="path-2" class="st2" points="154.6,172.6 145.8,177.4 131.8,179.4 112.8,165 108,126.6 102.6,72.2 155.3,150.8 204.2,74.5 199.7,120 195.6,164.1 179.8,179.4 164.7,178.4 " style="fill:#333333"/>
+                </g>
+                <path class="st3" d="m 108.5,126.5 4.8,38.2 18.6,14.1 13.7,-2 8.9,-4.8 10.3,5.8 14.8,1 15.5,-14.9 4.1,-43.9 4.3,-43.5 -48.2,75.2 -52,-77.6 z" id="path161" style="fill:none;stroke:#000000"/>
+              </g>
+              <path id="Rectangle-4-Copy-7" class="st4" d="m 152.2,59.4 c 0.8,-0.8 2,-0.8 2.8,0 l 9.9,9.9 c 0.8,0.8 0.6,1.8 -0.4,2.3 l -8.6,4.3 c -1,0.5 -2.6,0.5 -3.6,0.1 l -9.6,-4.4 c -1,-0.5 -1.2,-1.5 -0.4,-2.2 z" style="fill:#f5a623"/>
+            </g>
+          </g>
+          <g id="Group_1_" transform="rotate(20,46.247574,262.28303)">
+            <path id="Shape" d="m 115.2,21.5 c 0.1,1.4 0.2,2.9 0.4,4.3 0,2.6 -8.2,4.8 -18.3,4.8 C 87.2,30.6 79,28.5 79,25.8 v 0 c 0.2,-1.4 0.3,-2.8 0.4,-4.3 -7.4,1.4 -12.2,3.7 -12.2,6.3 0,4.3 13.5,7.9 30.1,7.9 16.6,0 30.1,-3.5 30.1,-7.9 -0.1,-2.6 -4.8,-4.9 -12.2,-6.3 z"/>
+            <path id="Shape_1_" class="st5" d="m 116.5,-7.5 c -0.6,2.8 -7.9,5 -19.2,5 -11.4,0 -18.7,-2.2 -19.2,-5 0,0 2.2,17.3 1.4,34 0.8,2.4 8.5,4.2 17.8,4.2 9.3,0 17,-1.9 17.8,-4.2 -0.8,-16.8 1.4,-34 1.4,-34 z" style="fill:#e54733"/>
+            <path id="Shape-Copy" d="m 118.5,-14.2 c -0.6,2.8 -9.9,5 -21.2,5 -11.4,0 -20.7,-2.2 -21.2,-5 0,0 4.2,17.3 3.4,34 0.8,2.4 8.5,4.2 17.8,4.2 9.3,0 17,-1.9 17.8,-4.2 -0.8,-16.7 3.4,-34 3.4,-34 z"/>
+            <path id="Shape_2_" d="m 118.6,-15.5 c 0,0.1 0,0.2 0,0.3 -0.6,2.8 -9.9,5 -21.2,5 -11.4,0 -20.7,-2.2 -21.2,-5 0,-0.1 0,-0.2 0,-0.3 0,-2.9 9.5,-5.3 21.3,-5.3 11.5,0 21.1,2.4 21.1,5.3 z"/>
+          </g>
+          <path id="Path-8-Copy" class="st6" d="m 132.6,139.7 c -0.9,-0.6 -1.6,-0.2 -1.5,0.9 l 2.1,26 c 0.1,1.1 0.9,1.5 1.8,0.9 L 174.7,140 c 0.9,-0.6 1.6,-0.2 1.6,0.9 v 25.3 c 0,1.1 -0.8,1.5 -1.7,0.9 z" style="fill:#e64934;stroke:#000000"/>
+          <g id="Group-2-Copy" transform="translate(81,174)">
+            <circle id="Oval-10-Copy" cx="72.400002" cy="5" r="2"/>
+            <circle id="Oval-10-Copy-2" cx="72.400002" cy="13" r="2"/>
+          </g>
+          <g id="SR-71-Copy-4" transform="rotate(-56,108.8957,180.16374)">
+            <g id="g177">
+              <path id="path-3" class="st2" d="m 133.7,239.1 v -0.6 c 0,-0.6 0.2,-1.1 0.5,-1.4 0.4,-0.3 0.8,-0.5 1.4,-0.5 0.3,0 0.5,0 0.8,0 0.9,0 1.7,0.1 2.3,0.4 v 1.5 c -0.6,-0.1 -1.4,-0.1 -2.4,-0.1 -0.3,0 -0.5,0 -0.6,0.1 -0.1,0 -0.2,0.2 -0.2,0.4 v 0.1 c 0,0.2 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.5,0.1 h 0.9 c 0.8,0 1.3,0.3 1.7,1 0.1,0.3 0.2,0.7 0.2,1.1 v 0.3 c 0,1.5 -0.7,2.2 -2,2.2 -1,0 -1.6,0 -1.9,0 -0.3,0 -0.7,-0.1 -1.2,-0.3 v -1.5 c 0.7,0.1 1.6,0.1 2.6,0.1 0.2,0 0.4,0 0.5,-0.1 0.1,-0.1 0.1,-0.2 0.1,-0.3 v -0.2 c 0,-0.2 0,-0.3 -0.1,-0.3 -0.1,-0.1 -0.2,-0.1 -0.4,-0.1 h -0.9 c -0.4,0 -0.7,-0.1 -0.9,-0.2 -0.3,-0.1 -0.5,-0.3 -0.6,-0.4 -0.1,-0.2 -0.2,-0.3 -0.3,-0.6 -0.1,-0.4 -0.1,-0.8 -0.1,-1.1 z m 6,4.8 v -7.3 h 3.3 c 0.7,0 1.3,0.2 1.7,0.5 0.4,0.4 0.6,1 0.6,1.8 0,0.8 -0.1,1.4 -0.4,1.7 -0.1,0.1 -0.2,0.3 -0.3,0.3 -0.1,0 -0.2,0.1 -0.4,0.2 l 1.3,2.8 h -2.2 l -0.9,-2.6 -0.6,-0.1 v 2.7 z m 1.9,-4.2 h 1.1 c 0.2,0 0.4,-0.1 0.4,-0.2 0.1,-0.1 0.1,-0.3 0.1,-0.6 0,-0.3 0,-0.5 -0.1,-0.6 -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 h -1.1 z m 4,2.1 v -1.5 h 3.1 v 1.5 z m 3.6,-3.5 v -1.7 h 4.8 l 0.5,0.8 -2.3,6.5 h -2.1 l 2,-5.6 z m 8.8,-1.7 v 7.3 h -1.9 v -5.5 l -1.2,0.2 v -1.2 l 1.2,-0.8 z" style="fill:#333333"/>
+            </g>
+            <g id="g180">
+              <path id="path-3_1_" d="m 133.7,239.1 v -0.6 c 0,-0.6 0.2,-1.1 0.5,-1.4 0.4,-0.3 0.8,-0.5 1.4,-0.5 0.3,0 0.5,0 0.8,0 0.9,0 1.7,0.1 2.3,0.4 v 1.5 c -0.6,-0.1 -1.4,-0.1 -2.4,-0.1 -0.3,0 -0.5,0 -0.6,0.1 -0.1,0 -0.2,0.2 -0.2,0.4 v 0.1 c 0,0.2 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.5,0.1 h 0.9 c 0.8,0 1.3,0.3 1.7,1 0.1,0.3 0.2,0.7 0.2,1.1 v 0.3 c 0,1.5 -0.7,2.2 -2,2.2 -1,0 -1.6,0 -1.9,0 -0.3,0 -0.7,-0.1 -1.2,-0.3 v -1.5 c 0.7,0.1 1.6,0.1 2.6,0.1 0.2,0 0.4,0 0.5,-0.1 0.1,-0.1 0.1,-0.2 0.1,-0.3 v -0.2 c 0,-0.2 0,-0.3 -0.1,-0.3 -0.1,-0.1 -0.2,-0.1 -0.4,-0.1 h -0.9 c -0.4,0 -0.7,-0.1 -0.9,-0.2 -0.3,-0.1 -0.5,-0.3 -0.6,-0.4 -0.1,-0.2 -0.2,-0.3 -0.3,-0.6 -0.1,-0.4 -0.1,-0.8 -0.1,-1.1 z m 6,4.8 v -7.3 h 3.3 c 0.7,0 1.3,0.2 1.7,0.5 0.4,0.4 0.6,1 0.6,1.8 0,0.8 -0.1,1.4 -0.4,1.7 -0.1,0.1 -0.2,0.3 -0.3,0.3 -0.1,0 -0.2,0.1 -0.4,0.2 l 1.3,2.8 h -2.2 l -0.9,-2.6 -0.6,-0.1 v 2.7 z m 1.9,-4.2 h 1.1 c 0.2,0 0.4,-0.1 0.4,-0.2 0.1,-0.1 0.1,-0.3 0.1,-0.6 0,-0.3 0,-0.5 -0.1,-0.6 -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 h -1.1 z m 4,2.1 v -1.5 h 3.1 v 1.5 z m 3.6,-3.5 v -1.7 h 4.8 l 0.5,0.8 -2.3,6.5 h -2.1 l 2,-5.6 z m 8.8,-1.7 v 7.3 h -1.9 v -5.5 l -1.2,0.2 v -1.2 l 1.2,-0.8 z"/>
+            </g>
+          </g>
+          <circle id="Oval-10" class="st7" cx="135.39999" cy="97" r="19" style="fill:#ffffff;fill-opacity:0.2;stroke:#ffffff;stroke-width:2"/>
+          <path id="Path-9" class="st8" d="m 116.9,93 c 0,0 -4.9,11.4 3.6,32.9 8.5,21.5 6.6,31.3 6.6,31.3" style="fill:none;stroke:#ffffff;stroke-width:2"/>
+        </g>
+      </g>
+    </g>
+  </g>
 </svg>

--- a/docs/img/oidc.svg
+++ b/docs/img/oidc.svg
@@ -1,100 +1,45 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 50 50"
-   version="1.1"
-   id="svg3799"
-   sodipodi:docname="oidc.svg"
-   width="50"
-   height="50"
-   inkscape:version="0.92.4 (f8dce91, 2019-08-02)">
-  <metadata
-     id="metadata3803">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>oidc</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1712"
-     inkscape:window-height="899"
-     id="namedview3801"
-     showgrid="false"
-     inkscape:zoom="6.075"
-     inkscape:cx="66.897654"
-     inkscape:cy="16.060002"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Layer_2"
-     fit-margin-top="10"
-     fit-margin-left="10"
-     fit-margin-right="10"
-     fit-margin-bottom="10" />
-  <defs
-     id="defs3780">
-    <style
-       id="style3778">.cls-1{fill:none;}.cls-2{fill:#f48018;}.cls-3{fill:#aeb0b3;}.cls-4{fill:#1a1818;}.cls-5,.cls-6{isolation:isolate;}.cls-6{font-size:21.44px;fill:#999;font-family:Helvetica, Helvetica;}</style>
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="100 0 100 100" width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+    text {
+      font: small Verdana, Helvetica, Arial, sans-serif;
+    }
+    .step {
+      animation-duration: 4s;
+      animation-iteration-count: infinite;
+    }
+    .step1 { animation-name: step1; }
+    .step2 { animation-name: step2; }
+    .step3 { animation-name: step3; }
+    .step4 { animation-name: step4; }
+
+    @keyframes step1 {
+      0% { opacity: 0; }
+      25% { opacity: 1; }
+    }
+    @keyframes step2 {
+      0% { opacity: 0; }
+      25% { opacity: 0; }
+      50% { opacity: 1; }
+    }
+    @keyframes step3 {
+      0% { opacity: 0; }
+      50% { opacity: 0; }
+      75% { opacity: 1; }
+    }
+    @keyframes step4 {
+      0% { opacity: 0; }
+      75% { opacity: 0; }
+      100% { opacity: 1; }
+    }
+  </style>
   </defs>
-  <title
-     id="title3782">oidc</title>
-  <g
-     id="Layer_2"
-     data-name="Layer 2"
-     transform="translate(-34.09,-16.059999)">
-    <rect
-       id="Rectangle-11"
-       class="cls-1"
-       width="200"
-       height="100"
-       x="0"
-       y="0"
-       style="fill:none" />
-    <polygon
-       id="Shape"
-       class="cls-2"
-       points="60.8,24.73 60.8,56.06 66.36,53.44 66.36,22.01 "
-       style="fill:#f48018"
-       transform="translate(-3.38,2.024999)" />
-    <path
-       id="Shape-2"
-       data-name="Shape"
-       class="cls-3"
-       d="m 46.27,46.164999 c 0,-4 4.3,-7.27 10.16,-8.29 v -3.53 c -9,1.08 -15.72,6 -15.72,11.82 0,6.07 7.26,11.09 16.71,11.92 v -3.49 c -6.36,-0.8 -11.15,-4.27 -11.15,-8.43 z m 20.43,-4.58 10.77,2.35 -0.77,-8 -2.86,1.61 a 25,25 0 0 0 -9.88,-3.21 v 3.53 a 17.37,17.37 0 0 1 6.08,2.2 l -0.32,-0.19 z"
-       inkscape:connector-curvature="0"
-       style="fill:#aeb0b3" />
-    <polygon
-       id="Shape-4"
-       data-name="Shape"
-       class="cls-2"
-       points="60.8,24.73 60.8,56.06 66.36,53.44 66.36,22.01 "
-       style="fill:#f48018"
-       transform="translate(-3.38,2.024999)" />
-    <path
-       id="Shape-5"
-       data-name="Shape"
-       class="cls-3"
-       d="m 46.27,46.164999 c 0,-4 4.3,-7.27 10.16,-8.29 v -3.53 c -9,1.08 -15.72,6 -15.72,11.82 0,6.07 7.26,11.09 16.71,11.92 v -3.49 c -6.36,-0.8 -11.15,-4.27 -11.15,-8.43 z"
-       inkscape:connector-curvature="0"
-       style="fill:#aeb0b3" />
+  <g id="Layer_2" data-name="Layer 2" transform="matrix(2, 0, 0, 2, 72.529999, -250)">
+    <rect id="Rectangle-11" class="cls-1" width="50" height="50" style="fill:none" x="13.735" y="125"/>
+    <polygon id="polygon-1" class="cls-2" points="37.065 135.695 37.065 167.025 42.625 164.405 42.625 132.975" style="fill:#f48018"/>
+    <path id="Shape-2" data-name="Shape" class="cls-3" d="M 25.915 155.105 C 25.915 151.105 30.215 147.835 36.075 146.815 L 36.075 143.285 C 27.075 144.365 20.355 149.285 20.355 155.105 C 20.355 161.175 27.615 166.195 37.065 167.025 L 37.065 163.535 C 30.705 162.735 25.915 159.265 25.915 155.105 Z M 46.345 150.525 L 57.115 152.875 L 56.345 144.875 L 53.485 146.485 C 50.453 144.735 47.087 143.641 43.605 143.275 L 43.605 146.805 C 45.751 147.151 47.814 147.898 49.685 149.005 L 49.365 148.815 Z" style="fill:#aeb0b3"/>
+    <polygon id="Shape-4" data-name="Shape" class="cls-2" points="37.065 135.695 37.065 167.025 42.625 164.405 42.625 132.975" style="fill:#f48018"/>
+    <path id="Shape-5" data-name="Shape" class="cls-3" d="M 25.915 155.105 C 25.915 151.105 30.215 147.835 36.075 146.815 L 36.075 143.285 C 27.075 144.365 20.355 149.285 20.355 155.105 C 20.355 161.175 27.615 166.195 37.065 167.025 L 37.065 163.535 C 30.705 162.735 25.915 159.265 25.915 155.105 Z" style="fill:#aeb0b3"/>
   </g>
 </svg>


### PR DESCRIPTION
The nested svg images for the kubeflow, oidc, etc icons fail to render in browser and the animated svg's contained some errors. I regenerated the svg's with the icons imported directly to avoid the nesting issue. I also fixed up the oidc.svg box sizing as it was not centered and rectangular rather than square. 