### PR TITLE
Simplify bundle yamls

### DIFF
--- a/bundle-edge.yaml
+++ b/bundle-edge.yaml
@@ -1,22 +1,19 @@
 bundle: kubernetes
 applications:
   argo-controller:
-    charm: cs:~kubeflow-charmers/argo-controller
-    source: ./charms/argo-controller
+    charm: argo-controller
     scale: 1
     annotations:
       gui-x: '0'
       gui-y: '-300'
   minio:
-    charm: cs:~kubeflow-charmers/minio
-    source: ./charms/minio
+    charm: minio
     scale: 1
     annotations:
       gui-x: '0'
       gui-y: '0'
   pipelines-api:
-    charm: cs:~kubeflow-charmers/pipelines-api
-    source: ./charms/pipelines-api
+    charm: pipelines-api
     scale: 1
     annotations:
       gui-x: '0'
@@ -28,36 +25,31 @@ applications:
       gui-x: '-300'
       gui-y: '300'
   pipelines-persistence:
-    charm: cs:~kubeflow-charmers/pipelines-persistence
-    source: ./charms/pipelines-persistence
+    charm: pipelines-persistence
     scale: 1
     annotations:
       gui-x: '300'
       gui-y: '300'
   pipelines-scheduledworkflow:
-    charm: cs:~kubeflow-charmers/pipelines-scheduledworkflow
-    source: ./charms/pipelines-scheduledworkflow
+    charm: pipelines-scheduledworkflow
     scale: 1
     annotations:
       gui-x: '300'
       gui-y: '0'
   pytorch-operator:
-    charm: cs:~kubeflow-charmers/pytorch-operator
-    source: ./charms/pytorch-operator
+    charm: pytorch-operator
     scale: 1
     annotations:
       gui-x: '-300'
       gui-y: '-300'
   seldon-core:
-    charm: cs:~kubeflow-charmers/seldon-core
-    source: ./charms/seldon-core
+    charm: seldon-core
     scale: 1
     annotations:
       gui-x: '-300'
       gui-y: '0'
   tf-job-operator:
-    charm: cs:~kubeflow-charmers/tf-job-operator
-    source: ./charms/tf-job-operator
+    charm: tf-job-operator
     scale: 1
     annotations:
       gui-x: '300'

--- a/bundle-lite.yaml
+++ b/bundle-lite.yaml
@@ -1,71 +1,61 @@
 bundle: kubernetes
 applications:
   ambassador:
-    charm: cs:~kubeflow-charmers/ambassador
-    source: ./charms/ambassador
+    charm: ambassador
     scale: 1
     annotations:
       gui-x: '300'
       gui-y: '-518'
   argo-controller:
-    charm: cs:~kubeflow-charmers/argo-controller
-    source: ./charms/argo-controller
+    charm: argo-controller
     scale: 1
     annotations:
       gui-x: '150'
       gui-y: '259'
   dex-auth:
-    charm: cs:~kubeflow-charmers/dex-auth
-    source: ./charms/dex-auth
+    charm: dex-auth
     scale: 1
     annotations:
       gui-x: '-600'
       gui-y: '0'
   jupyter-controller:
-    charm: cs:~kubeflow-charmers/jupyter-controller
-    source: ./charms/jupyter-controller
+    charm: jupyter-controller
     scale: 1
     annotations:
       gui-x: '600'
       gui-y: '0'
   jupyter-web:
-    charm: cs:~kubeflow-charmers/jupyter-web
-    source: ./charms/jupyter-web
+    charm: jupyter-web
     scale: 1
     annotations:
       gui-x: '450'
       gui-y: '-259'
   kubeflow-dashboard:
-    charm: cs:~kubeflow-charmers/kubeflow-dashboard
-    source: ./charms/kubeflow-dashboard
+    charm: kubeflow-dashboard
     scale: 1
     annotations:
       gui-x: '450'
       gui-y: '259'
   kubeflow-profiles:
-    charm: cs:~kubeflow-charmers/kubeflow-profiles
-    source: ./charms/kubeflow-profiles
+    charm: kubeflow-profiles
     scale: 1
     annotations:
       gui-x: '300'
       gui-y: '0'
   minio:
-    charm: cs:~kubeflow-charmers/minio
-    source: ./charms/minio
+    charm: minio
     scale: 1
     annotations:
       gui-x: '-150'
       gui-y: '-259'
   oidc-gatekeeper:
-    charm: cs:~kubeflow-charmers/oidc-gatekeeper
-    source: ./charms/oidc-gatekeeper
+    charm: oidc-gatekeeper
     scale: 1
     annotations:
       gui-x: '-450'
       gui-y: '259'
   pipelines-api:
-    charm: cs:~kubeflow-charmers/pipelines-api
-    source: ./charms/pipelines-api
+    charm: pipelines-api
     scale: 1
     annotations:
       gui-x: '0'
@@ -77,57 +67,49 @@ applications:
       gui-x: '-450'
       gui-y: '-259'
   pipelines-persistence:
-    charm: cs:~kubeflow-charmers/pipelines-persistence
-    source: ./charms/pipelines-persistence
+    charm: pipelines-persistence
     scale: 1
     annotations:
       gui-x: '-300'
       gui-y: '0'
   pipelines-scheduledworkflow:
-    charm: cs:~kubeflow-charmers/pipelines-scheduledworkflow
-    source: ./charms/pipelines-scheduledworkflow
+    charm: pipelines-scheduledworkflow
     scale: 1
     annotations:
       gui-x: '-300'
       gui-y: '-518'
   pipelines-ui:
-    charm: cs:~kubeflow-charmers/pipelines-ui
-    source: ./charms/pipelines-ui
+    charm: pipelines-ui
     scale: 1
     annotations:
       gui-x: '0'
       gui-y: '-518'
   pipelines-viewer:
-    charm: cs:~kubeflow-charmers/pipelines-viewer
-    source: ./charms/pipelines-viewer
+    charm: pipelines-viewer
     scale: 1
     annotations:
       gui-x: '150'
       gui-y: '-259'
   pipelines-visualization:
-    charm: cs:~kubeflow-charmers/pipelines-visualization
-    source: ./charms/pipelines-visualization
+    charm: pipelines-visualization
     scale: 1
     annotations:
       gui-x: '-150'
       gui-y: '259'
   pytorch-operator:
-    charm: cs:~kubeflow-charmers/pytorch-operator
-    source: ./charms/pytorch-operator
+    charm: pytorch-operator
     scale: 1
     annotations:
       gui-x: '-300'
       gui-y: '518'
   seldon-core:
-    charm: cs:~kubeflow-charmers/seldon-core
-    source: ./charms/seldon-core
+    charm: seldon-core
     scale: 1
     annotations:
       gui-x: '0'
       gui-y: '518'
   tf-job-operator:
-    charm: cs:~kubeflow-charmers/tf-job-operator
-    source: ./charms/tf-job-operator
+    charm: tf-job-operator
     scale: 1
     annotations:
       gui-x: '300'

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,50 +1,43 @@
 bundle: kubernetes
 applications:
   ambassador:
-    charm: cs:~kubeflow-charmers/ambassador
-    source: ./charms/ambassador
+    charm: ambassador
     scale: 1
     annotations:
       gui-x: '0'
       gui-y: '0'
   argo-controller:
-    charm: cs:~kubeflow-charmers/argo-controller
-    source: ./charms/argo-controller
+    charm: argo-controller
     scale: 1
     annotations:
       gui-x: '600'
       gui-y: '0'
   argo-ui:
-    charm: cs:~kubeflow-charmers/argo-ui
-    source: ./charms/argo-ui
+    charm: argo-ui
     scale: 1
     annotations:
       gui-x: '300'
       gui-y: '0'
   dex-auth:
-    charm: cs:~kubeflow-charmers/dex-auth
-    source: ./charms/dex-auth
+    charm: dex-auth
     scale: 1
     annotations:
       gui-x: '600'
       gui-y: '-518'
   jupyter-controller:
-    charm: cs:~kubeflow-charmers/jupyter-controller
-    source: ./charms/jupyter-controller
+    charm: jupyter-controller
     scale: 1
     annotations:
       gui-x: '450'
       gui-y: '-259'
   jupyter-web:
-    charm: cs:~kubeflow-charmers/jupyter-web
-    source: ./charms/jupyter-web
+    charm: jupyter-web
     scale: 1
     annotations:
       gui-x: '150'
       gui-y: '-259'
   katib-controller:
-    charm: cs:~kubeflow-charmers/katib-controller
-    source: ./charms/katib-controller
+    charm: katib-controller
     scale: 1
     annotations:
       gui-x: '-450'
@@ -58,43 +51,37 @@ applications:
       gui-x: '-600'
       gui-y: '518'
   katib-db-manager:
-    charm: cs:~kubeflow-charmers/katib-manager
-    source: ./charms/katib-manager
+    charm: katib-manager
     scale: 1
     annotations:
       gui-x: '-750'
       gui-y: '259'
   katib-ui:
-    charm: cs:~kubeflow-charmers/katib-ui
-    source: ./charms/katib-ui
+    charm: katib-ui
     scale: 1
     annotations:
       gui-x: '-150'
       gui-y: '259'
   kubeflow-dashboard:
-    charm: cs:~kubeflow-charmers/kubeflow-dashboard
-    source: ./charms/kubeflow-dashboard
+    charm: kubeflow-dashboard
     scale: 1
     annotations:
       gui-x: '750'
       gui-y: '259'
   kubeflow-profiles:
-    charm: cs:~kubeflow-charmers/kubeflow-profiles
-    source: ./charms/kubeflow-profiles
+    charm: kubeflow-profiles
     scale: 1
     annotations:
       gui-x: '600'
       gui-y: '518'
   metacontroller:
-    charm: cs:~kubeflow-charmers/metacontroller
-    source: ./charms/metacontroller
+    charm: metacontroller
     scale: 1
     annotations:
       gui-x: '-300'
       gui-y: '518'
   metadata-api:
-    charm: cs:~kubeflow-charmers/metadata-api
-    source: ./charms/metadata-api
+    charm: metadata-api
     scale: 1
     annotations:
       gui-x: '-300'
@@ -106,43 +93,37 @@ applications:
       gui-x: '-600'
       gui-y: '-518'
   metadata-envoy:
-    charm: cs:~kubeflow-charmers/metadata-envoy
-    source: ./charms/metadata-envoy
+    charm: metadata-envoy
     scale: 1
     annotations:
       gui-x: '-750'
       gui-y: '-259'
   metadata-grpc:
-    charm: cs:~kubeflow-charmers/metadata-grpc
-    source: ./charms/metadata-grpc
+    charm: metadata-grpc
     scale: 1
     annotations:
       gui-x: '-450'
       gui-y: '-259'
   metadata-ui:
-    charm: cs:~kubeflow-charmers/metadata-ui
-    source: ./charms/metadata-ui
+    charm: metadata-ui
     scale: 1
     annotations:
       gui-x: '-150'
       gui-y: '-259'
   minio:
-    charm: cs:~kubeflow-charmers/minio
-    source: ./charms/minio
+    charm: minio
     scale: 1
     annotations:
       gui-x: '450'
       gui-y: '259'
   oidc-gatekeeper:
-    charm: cs:~kubeflow-charmers/oidc-gatekeeper
-    source: ./charms/oidc-gatekeeper
+    charm: oidc-gatekeeper
     scale: 1
     annotations:
       gui-x: '750'
       gui-y: '-259'
   pipelines-api:
-    charm: cs:~kubeflow-charmers/pipelines-api
-    source: ./charms/pipelines-api
+    charm: pipelines-api
     scale: 1
     annotations:
       gui-x: '300'
@@ -154,57 +135,49 @@ applications:
       gui-x: '0'
       gui-y: '518'
   pipelines-persistence:
-    charm: cs:~kubeflow-charmers/pipelines-persistence
-    source: ./charms/pipelines-persistence
+    charm: pipelines-persistence
     scale: 1
     annotations:
       gui-x: '150'
       gui-y: '777'
   pipelines-scheduledworkflow:
-    charm: cs:~kubeflow-charmers/pipelines-scheduledworkflow
-    source: ./charms/pipelines-scheduledworkflow
+    charm: pipelines-scheduledworkflow
     scale: 1
     annotations:
       gui-x: '-150'
       gui-y: '777'
   pipelines-ui:
-    charm: cs:~kubeflow-charmers/pipelines-ui
-    source: ./charms/pipelines-ui
+    charm: pipelines-ui
     scale: 1
     annotations:
       gui-x: '150'
       gui-y: '259'
   pipelines-viewer:
-    charm: cs:~kubeflow-charmers/pipelines-viewer
-    source: ./charms/pipelines-viewer
+    charm: pipelines-viewer
     scale: 1
     annotations:
       gui-x: '-300'
       gui-y: '0'
   pipelines-visualization:
-    charm: cs:~kubeflow-charmers/pipelines-visualization
-    source: ./charms/pipelines-visualization
+    charm: pipelines-visualization
     scale: 1
     annotations:
       gui-x: '450'
       gui-y: '777'
   pytorch-operator:
-    charm: cs:~kubeflow-charmers/pytorch-operator
-    source: ./charms/pytorch-operator
+    charm: pytorch-operator
     scale: 1
     annotations:
       gui-x: '450'
       gui-y: '-777'
   seldon-core:
-    charm: cs:~kubeflow-charmers/seldon-core
-    source: ./charms/seldon-core
+    charm: seldon-core
     scale: 1
     annotations:
       gui-x: '900'
       gui-y: '0'
   tf-job-operator:
-    charm: cs:~kubeflow-charmers/tf-job-operator
-    source: ./charms/tf-job-operator
+    charm: tf-job-operator
     scale: 1
     annotations:
       gui-x: '-600'


### PR DESCRIPTION
Each charm has now been promulgated, and so can use e.g. `foo` instead of `cs:~kubeflow-charmers/foo`. Additionally, juju-bundle will now build a charm locally if the charm source is sitting under `charms/`, so the `source:` tags can be removed.