### PR TITLE
Microk8s usage updates

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -129,7 +129,7 @@ def microk8s_info(model):
     print(
         textwrap.dedent(
             f"""
-        Run `microk8s.kubectl proxy` to be able to access the dashboard at
+        Run `microk8s kubectl proxy` to be able to access the dashboard at
 
         http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/overview?namespace={model}
         """
@@ -471,16 +471,17 @@ def microk8s():
 )
 @click.option('--test-mode/--no-test-mode', default=False)
 def setup(controller, services, test_mode):
-    check_for('microk8s.enable', snap_name='microk8s')
+    check_for('microk8s')
 
     if not controller:
         controller = DEFAULT_CONTROLLERS['microk8s']
 
     for service in services:
-        click.secho(f'Running microk8s.enable {service}', fg='green')
-        run('microk8s.enable', service)
+        click.secho(f'Running microk8s enable {service}', fg='green')
+        run('microk8s', 'enable', service)
         wait_for(
-            'microk8s.status',
+            'microk8s',
+            'status',
             '--wait-ready',
             wait_msg='Waiting for microk8s to become ready...',
             fail_msg=f'Couldn\'t enable {service}!',
@@ -488,7 +489,8 @@ def setup(controller, services, test_mode):
         click.echo('\n')
 
     wait_for(
-        "microk8s.kubectl",
+        "microk8s",
+        "kubectl",
         "wait",
         "--for=condition=available",
         "-nkube-system",

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import shutil
 import string
 import subprocess
 import sys
@@ -8,7 +9,6 @@ import tempfile
 import textwrap
 import time
 from pathlib import Path
-import shutil
 from typing import Optional
 
 import click
@@ -67,7 +67,11 @@ def get_output(*args: str):
     """Gets output from subcommand without echoing stdout."""
 
     return subprocess.run(
-        args, check=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        args,
+        check=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     ).stdout
 
 
@@ -236,7 +240,8 @@ def cli(debug):
 @click.option('--build/--no-build', default=False)
 @click.option('-o', '--overlays', multiple=True)
 @click.password_option(
-    envvar='KUBEFLOW_AUTH_PASSWORD', prompt='Enter a password to set for the Kubeflow dashboard',
+    envvar='KUBEFLOW_AUTH_PASSWORD',
+    prompt='Enter a password to set for the Kubeflow dashboard',
 )
 def deploy_to(controller, cloud, model, bundle, channel, public_address, build, overlays, password):
     check_for('juju')
@@ -557,7 +562,11 @@ def setup(cloud, region, controller, channel, test_mode, gpu):
     with tempfile.NamedTemporaryFile() as kubeconfig:
         # Copy details of cloud locally, and tell juju about it
         juju(
-            'scp', '-m', f'{controller}:default', 'kubernetes-master/0:~/config', kubeconfig.name,
+            'scp',
+            '-m',
+            f'{controller}:default',
+            'kubernetes-master/0:~/config',
+            kubeconfig.name,
         )
         juju(
             'add-k8s',


### PR DESCRIPTION
Uses e.g. `microk8s enable` instead of `microk8s.enable`, since that syntax is now supported.