### PR TITLE
Don't fail fast on Github CI actions

### DIFF
--- a/.github/workflows/test-microk8s.yaml
+++ b/.github/workflows/test-microk8s.yaml
@@ -9,6 +9,7 @@ jobs:
     name: Github Actions
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         microk8s: [stable, edge]
         bundle: [lite, edge]
@@ -62,6 +63,7 @@ jobs:
     name: AWS
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         microk8s: [stable, edge]
     steps:


### PR DESCRIPTION
Failing fast means we don't find out if one job in particular is flakey or if it's a general issue.