### PR TITLE
Specify namespace when publishing bundle in CI

### DIFF
--- a/.github/workflows/publish-bundle.yaml
+++ b/.github/workflows/publish-bundle.yaml
@@ -28,7 +28,12 @@ jobs:
         echo $CHARMSTORE_CREDENTIAL > ~/.go-cookies
         git clone git://git.launchpad.net/canonical-osm
         cp -r canonical-osm/charms/interfaces/juju-relation-mysql mysql
-        juju-bundle publish -b bundle.yaml --url cs:~kubeflow-charmers/kubeflow --serial --prune --publish-charms
+        juju-bundle publish \
+            -b bundle.yaml \
+            --url cs:~kubeflow-charmers/kubeflow \
+            --serial --prune \
+            --publish-charms \
+            --publish-namespace kubeflow-charmers
         juju-bundle publish -b bundle-lite.yaml --url cs:~kubeflow-charmers/kubeflow-lite
         juju-bundle publish -b bundle-edge.yaml --url cs:~kubeflow-charmers/kubeflow-edge
 


### PR DESCRIPTION
Otherwise, with the switch to charm URLs of just e.g. `minio`, the charms get published to `cs:~username/minio`, where `username` is the username for the credentials used.