### PR TITLE
Better katib-controller webhook handling

### DIFF
--- a/charms/katib-controller/reactive/katib_controller.py
+++ b/charms/katib-controller/reactive/katib_controller.py
@@ -252,8 +252,6 @@ def start_charm():
                         '-webhook-port',
                         str(config['webhook-port']),
                         '-logtostderr',
-                        '-webhook-service-name',
-                        'katib-controller-old',
                         '-v=4',
                     ],
                     'imageDetails': {
@@ -288,6 +286,7 @@ def start_charm():
                 "mutatingWebhookConfigurations": [
                     {
                         "name": "katib-mutating-webhook-config",
+                        "annotations": {"juju.io/disable-name-prefix": "true"},
                         "webhooks": [
                             {
                                 "name": "mutating.experiment.katib.kubeflow.org",
@@ -339,6 +338,7 @@ def start_charm():
                 "validatingWebhookConfigurations": [
                     {
                         "name": "katib-validating-webhook-config",
+                        "annotations": {"juju.io/disable-name-prefix": "true"},
                         "webhooks": [
                             {
                                 "name": "validating.experiment.katib.kubeflow.org",

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -349,14 +349,6 @@ def deploy_to(controller, cloud, model, bundle, channel, public_address, build, 
         "--all",
     )
 
-    if bundle == 'full':
-        juju(
-            'kubectl',
-            'delete',
-            'mutatingwebhookconfigurations/katib-mutating-webhook-config',
-            'validatingwebhookconfigurations/katib-validating-webhook-config',
-        )
-
     if bundle in ('full', 'lite'):
         pub_addr = public_address or get_pub_addr(controller)
         juju('config', 'dex-auth', f'public-url=http://{pub_addr}:80')


### PR DESCRIPTION
Create a webhook with the same name as the one that the upstream code attempts to create, since we create it correctly, and the upstream code will simply skip creating it if it already exists.