### PR TITLE
Work around katib-controller behavior

### DIFF
--- a/.github/workflows/test-microk8s.yaml
+++ b/.github/workflows/test-microk8s.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        juju: [2.8/edge]
+        juju: [2.8/stable]
         microk8s: [1.18/stable, 1.18/candidate, 1.18/beta, 1.18/edge]
     steps:
     - name: Check out code
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        juju: [2.8/edge]
+        juju: [2.8/stable]
         microk8s: [1.18/stable, 1.18/candidate, 1.18/beta, 1.18/edge]
         bundle: [lite, full]
     steps:
@@ -110,7 +110,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo snap install juju --classic --channel 2.8/edge
+        sudo snap install juju --classic
         sudo snap install juju-wait --classic
 
     - name: Bootstrap onto AWS

--- a/charms/katib-controller/config.yaml
+++ b/charms/katib-controller/config.yaml
@@ -1,7 +1,7 @@
 options:
   webhook-port:
     type: int
-    default: 8443
+    default: 443
     description: Webhook port
   metrics-port:
     type: int

--- a/charms/katib-controller/metadata.yaml
+++ b/charms/katib-controller/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:v0.9.0
+    upstream-source: rocks.canonical.com:5000/kubeflow/katib-controller:latest
 requires:
   mysql:
     interface: mysql

--- a/charms/katib-controller/reactive/katib_controller.py
+++ b/charms/katib-controller/reactive/katib_controller.py
@@ -1,8 +1,6 @@
 import json
 import os
-from base64 import b64encode
 from pathlib import Path
-from subprocess import check_call
 
 import yaml
 
@@ -65,105 +63,6 @@ KATIB_CONFIG = {
 }
 
 
-def gen_certs(namespace, service_name):
-    if Path('/run/cert.pem').exists():
-        hookenv.log("Found existing cert.pem, not generating new cert.")
-        return
-
-    Path('/run/ssl.conf').write_text(
-        f"""[ req ]
-default_bits = 2048
-prompt = no
-default_md = sha256
-req_extensions = req_ext
-distinguished_name = dn
-
-[ dn ]
-C = GB
-ST = Canonical
-L = Canonical
-O = Canonical
-OU = Canonical
-CN = 127.0.0.1
-
-[ req_ext ]
-subjectAltName = @alt_names
-
-[ alt_names ]
-DNS.1 = {service_name}
-DNS.2 = {service_name}.{namespace}
-DNS.3 = {service_name}.{namespace}.svc
-DNS.4 = {service_name}.{namespace}.svc.cluster
-DNS.5 = {service_name}.{namespace}.svc.cluster.local
-IP.1 = 127.0.0.1
-
-[ v3_ext ]
-authorityKeyIdentifier=keyid,issuer:always
-basicConstraints=CA:FALSE
-keyUsage=keyEncipherment,dataEncipherment,digitalSignature
-extendedKeyUsage=serverAuth,clientAuth
-subjectAltName=@alt_names"""
-    )
-
-    check_call(['openssl', 'genrsa', '-out', '/run/ca.key', '2048'])
-    check_call(['openssl', 'genrsa', '-out', '/run/server.key', '2048'])
-    check_call(
-        [
-            'openssl',
-            'req',
-            '-x509',
-            '-new',
-            '-sha256',
-            '-nodes',
-            '-days',
-            '3650',
-            '-key',
-            '/run/ca.key',
-            '-subj',
-            '/CN=127.0.0.1',
-            '-out',
-            '/run/ca.crt',
-        ]
-    )
-    check_call(
-        [
-            'openssl',
-            'req',
-            '-new',
-            '-sha256',
-            '-key',
-            '/run/server.key',
-            '-out',
-            '/run/server.csr',
-            '-config',
-            '/run/ssl.conf',
-        ]
-    )
-    check_call(
-        [
-            'openssl',
-            'x509',
-            '-req',
-            '-sha256',
-            '-in',
-            '/run/server.csr',
-            '-CA',
-            '/run/ca.crt',
-            '-CAkey',
-            '/run/ca.key',
-            '-CAcreateserial',
-            '-out',
-            '/run/cert.pem',
-            '-days',
-            '365',
-            '-extensions',
-            'v3_ext',
-            '-extfile',
-            '/run/ssl.conf',
-        ]
-    )
-
-
 @when('layer.docker-resource.oci-image.available')
 @when_not('charm.started')
 def start_charm():
@@ -174,11 +73,7 @@ def start_charm():
     layer.status.maintenance('configuring container')
 
     image_info = layer.docker_resource.get_info('oci-image')
-    namespace = os.environ["JUJU_MODEL_NAME"]
     config = dict(hookenv.config())
-
-    gen_certs(namespace, hookenv.service_name())
-    ca_bundle = b64encode(Path('/run/cert.pem').read_bytes()).decode('utf-8')
 
     layer.caas_base.pod_spec_set(
         {
@@ -253,6 +148,7 @@ def start_charm():
                         str(config['webhook-port']),
                         '-logtostderr',
                         '-v=4',
+                        '-cert-localfs=true',
                     ],
                     'imageDetails': {
                         'imagePath': image_info.registry_path,
@@ -264,16 +160,7 @@ def start_charm():
                         {'name': 'metrics', 'containerPort': config['metrics-port']},
                     ],
                     'envConfig': {'KATIB_CORE_NAMESPACE': os.environ['JUJU_MODEL_NAME']},
-                    'volumeConfig': [
-                        {
-                            'name': 'cert',
-                            'mountPath': '/tmp/cert',
-                            'files': [
-                                {'path': 'cert.pem', 'content': Path('/run/cert.pem').read_text()},
-                                {'path': 'key.pem', 'content': Path('/run/server.key').read_text()},
-                            ],
-                        }
-                    ],
+                    'kubernetes': {'securityContext': {'runAsUser': 0}},
                 }
             ],
         },
@@ -282,89 +169,6 @@ def start_charm():
                 'customResourceDefinitions': [
                     {'name': crd['metadata']['name'], 'spec': crd['spec']}
                     for crd in yaml.safe_load_all(Path("files/crds.yaml").read_text())
-                ],
-                "mutatingWebhookConfigurations": [
-                    {
-                        "name": "katib-mutating-webhook-config",
-                        "annotations": {"model.juju.is/disable-prefix": "true"},
-                        "webhooks": [
-                            {
-                                "name": "mutating.experiment.katib.kubeflow.org",
-                                "rules": [
-                                    {
-                                        'apiGroups': ['kubeflow.org'],
-                                        'apiVersions': ['v1alpha3'],
-                                        'operations': ['CREATE', 'UPDATE'],
-                                        'resources': ['experiments'],
-                                        'scope': '*',
-                                    }
-                                ],
-                                "failurePolicy": "Fail",
-                                "clientConfig": {
-                                    "service": {
-                                        "name": hookenv.service_name(),
-                                        "namespace": namespace,
-                                        "path": "/mutate-experiments",
-                                        "port": config['webhook-port'],
-                                    },
-                                    "caBundle": ca_bundle,
-                                },
-                            },
-                            {
-                                "name": "mutating.pod.katib.kubeflow.org",
-                                "rules": [
-                                    {
-                                        'apiGroups': [''],
-                                        'apiVersions': ['v1'],
-                                        'operations': ['CREATE'],
-                                        'resources': ['pods'],
-                                        'scope': '*',
-                                    }
-                                ],
-                                "failurePolicy": "Ignore",
-                                "clientConfig": {
-                                    "service": {
-                                        "name": hookenv.service_name(),
-                                        "namespace": namespace,
-                                        "path": "/mutate-pods",
-                                        "port": config['webhook-port'],
-                                    },
-                                    "caBundle": ca_bundle,
-                                },
-                            },
-                        ],
-                    }
-                ],
-                "validatingWebhookConfigurations": [
-                    {
-                        "name": "katib-validating-webhook-config",
-                        "annotations": {"model.juju.is/disable-prefix": "true"},
-                        "webhooks": [
-                            {
-                                "name": "validating.experiment.katib.kubeflow.org",
-                                "rules": [
-                                    {
-                                        "apiGroups": ["kubeflow.org"],
-                                        "apiVersions": ["v1alpha3"],
-                                        "operations": ["CREATE", "UPDATE"],
-                                        "resources": ["experiments"],
-                                        'scope': '*',
-                                    }
-                                ],
-                                "failurePolicy": "Fail",
-                                "sideEffects": "Unknown",
-                                "clientConfig": {
-                                    "service": {
-                                        "name": hookenv.service_name(),
-                                        "namespace": namespace,
-                                        "path": "/validate-experiments",
-                                        "port": config['webhook-port'],
-                                    },
-                                    "caBundle": ca_bundle,
-                                },
-                            }
-                        ],
-                    }
                 ],
             },
             'configMaps': {

--- a/charms/katib-manager/reactive/katib_manager.py
+++ b/charms/katib-manager/reactive/katib_manager.py
@@ -35,7 +35,7 @@ def start_charm():
 
     layer.caas_base.pod_spec_set(
         {
-            'version': 2,
+            'version': 3,
             'containers': [
                 {
                     'name': 'katib-manager',
@@ -46,7 +46,7 @@ def start_charm():
                         'password': image_info.password,
                     },
                     'ports': [{'name': 'api', 'containerPort': port}],
-                    'config': {
+                    'envConfig': {
                         'DB_NAME': 'mysql',
                         'DB_USER': 'root',
                         'DB_PASSWORD': mysql.root_password(),
@@ -68,7 +68,23 @@ def start_charm():
                     },
                 }
             ],
-        }
+        },
+        k8s_resources={
+            'kubernetesResources': {
+                'services': [
+                    {
+                        'name': 'katib-db-manager',
+                        'spec': {
+                            'ports': [
+                                {'name': 'api', 'port': 6789, 'protocol': 'TCP', 'targetPort': 6789}
+                            ],
+                            'selector': {'juju-app': 'katib-manager'},
+                            'type': 'ClusterIP',
+                        },
+                    }
+                ]
+            }
+        },
     )
 
     layer.status.maintenance('creating container')

--- a/tests/pipelines/katib.py
+++ b/tests/pipelines/katib.py
@@ -68,6 +68,10 @@ def wait_task(namespace: str, experiment_name: str):
         elif set(statuses.values()) == {'Succeeded'}:
             print("All jobs completed successfully!")
             break
+        elif 'Failed' in statuses:
+            print("Got failed status!")
+            print(statuses)
+            break
         else:
             print('Waiting for jobs to complete:')
             print(statuses)
@@ -87,9 +91,7 @@ def delete_task(namespace: str, experiment_name: str):
     response.raise_for_status()
 
 
-@dsl.pipeline(
-    name='Katib Test', description='Tests Katib',
-)
+@dsl.pipeline(name='Katib Test', description='Tests Katib')
 def katib_pipeline(
     namespace: str = 'admin',
     example: str = 'https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1alpha3/grid-example.yaml',


### PR DESCRIPTION
The katib-controller code really, really wants to overwrite bits of Kubernetes infrastructure, which includes bits of infra that the charm sets up via Juju. The upstream code also is hardcoded to set the service up as using the label `app: katib-controller`, whereas Juju labels the pod as `juju-app: katib-controller`.

So, the upstream code got forked to just set up the infrastructure correctly, and this charm can just use the r.c.c docker image that uses that forked code.