### PR TITLE
Fixing istio charm store references

### DIFF
--- a/bundle-lite.yaml
+++ b/bundle-lite.yaml
@@ -2,8 +2,8 @@ bundle: kubernetes
 applications:
   argo-controller:              { charm: argo-controller,             scale: 1, annotations: { gui-x:  '600', gui-y:    '0' } }
   dex-auth:                     { charm: dex-auth,                    scale: 1, annotations: { gui-x:  '600', gui-y: '-518' } }
-  istio-ingressgateway:         { charm: istio-ingressgateway-5,      scale: 1, annotations: { gui-x:    '0', gui-y:    '0' } }
-  istio-pilot:                  { charm: istio-pilot-5,               scale: 1, annotations: { gui-x:    '0', gui-y:    '0' } }
+  istio-ingressgateway:         { charm: cs:istio-ingressgateway-5,   scale: 1, annotations: { gui-x:    '0', gui-y:    '0' } }
+  istio-pilot:                  { charm: cs:istio-pilot-5,            scale: 1, annotations: { gui-x:    '0', gui-y:    '0' } }
   jupyter-controller:           { charm: jupyter-controller,          scale: 1, annotations: { gui-x:  '450', gui-y: '-259' } }
   jupyter-web:                  { charm: jupyter-web,                 scale: 1, annotations: { gui-x:  '150', gui-y: '-259' } }
   kubeflow-dashboard:           { charm: kubeflow-dashboard,          scale: 1, annotations: { gui-x:  '750', gui-y:  '259' } }

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -3,8 +3,8 @@ applications:
   argo-controller:              { charm: argo-controller,             scale: 1, annotations: { gui-x:  '600', gui-y:    '0' } }
   argo-ui:                      { charm: argo-ui,                     scale: 1, annotations: { gui-x:  '300', gui-y:    '0' } }
   dex-auth:                     { charm: dex-auth,                    scale: 1, annotations: { gui-x:  '600', gui-y: '-518' } }
-  istio-ingressgateway:         { charm: istio-ingressgateway-5,      scale: 1, annotations: { gui-x:    '0', gui-y:    '0' } }
-  istio-pilot:                  { charm: istio-pilot-5,               scale: 1, annotations: { gui-x:    '0', gui-y:    '0' } }
+  istio-ingressgateway:         { charm: cs:istio-ingressgateway-5,   scale: 1, annotations: { gui-x:    '0', gui-y:    '0' } }
+  istio-pilot:                  { charm: cs:istio-pilot-5,            scale: 1, annotations: { gui-x:    '0', gui-y:    '0' } }
   jupyter-controller:           { charm: jupyter-controller,          scale: 1, annotations: { gui-x:  '450', gui-y: '-259' } }
   jupyter-web:                  { charm: jupyter-web,                 scale: 1, annotations: { gui-x:  '150', gui-y: '-259' } }
   katib-controller:             { charm: katib-controller,            scale: 1, annotations: { gui-x: '-450', gui-y:  '259' } }


### PR DESCRIPTION
Juju 2.9 requires `cs:` prefix to use the `-N` version specifier, otherwise it will look at charmhub.io for the charm, which doesn't support that syntax.