### PR TITLE
Use charmcraft pip install instead of snap

### DIFF
--- a/.github/workflows/publish-bundle.yaml
+++ b/.github/workflows/publish-bundle.yaml
@@ -18,8 +18,9 @@ jobs:
       run: |
         set -eux
         sudo snap install charm --classic
-        sudo snap install charmcraft --classic --channel edge
         sudo snap install juju-helpers --classic --channel edge
+        pip3 install --user charmcraft
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Publish bundle
       env:
@@ -37,4 +38,3 @@ jobs:
             --publish-namespace kubeflow-charmers
         juju-bundle publish -b bundle-lite.yaml --url cs:~kubeflow-charmers/kubeflow-lite
         juju-bundle publish -b bundle-edge.yaml --url cs:~kubeflow-charmers/kubeflow-edge
-


### PR DESCRIPTION
The snap is strictly confined, and can't pull down git dependencies due to a permissions error.