### PR TITLE
Make pipeline-runner role a clusterrole

### DIFF
--- a/charms/pipelines-api/reactive/pipelines_api.py
+++ b/charms/pipelines-api/reactive/pipelines_api.py
@@ -208,6 +208,7 @@ def start_charm():
                         'roles': [
                             {
                                 'name': 'pipeline-runner',
+                                'global': True,
                                 'rules': [
                                     {'apiGroups': [''], 'resources': ['secrets'], 'verbs': ['get']},
                                     {


### PR DESCRIPTION
Some pipelines seem to fail on AKS due to pipeline-runner not being a clusterrole.