### PR TITLE
Update admission-webhook cert handling

### DIFF
--- a/charms/admission-webhook/src/charm.py
+++ b/charms/admission-webhook/src/charm.py
@@ -3,18 +3,113 @@
 import os
 from base64 import b64encode
 from pathlib import Path
-from subprocess import run
 import logging
 
 import yaml
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus
+from subprocess import check_call
 
 from charmhelpers.core import hookenv
 from oci_image import OCIImageResource, OCIImageResourceError
 
 logger = logging.getLogger(__name__)
+
+
+def gen_certs(namespace, service_name):
+    if Path('/run/cert.pem').exists():
+        hookenv.log("Found existing cert.pem, not generating new cert.")
+        return
+
+    Path('/run/ssl.conf').write_text(
+        f"""[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+[ dn ]
+C = GB
+ST = Canonical
+L = Canonical
+O = Canonical
+OU = Canonical
+CN = 127.0.0.1
+[ req_ext ]
+subjectAltName = @alt_names
+[ alt_names ]
+DNS.1 = {service_name}
+DNS.2 = {service_name}.{namespace}
+DNS.3 = {service_name}.{namespace}.svc
+DNS.4 = {service_name}.{namespace}.svc.cluster
+DNS.5 = {service_name}.{namespace}.svc.cluster.local
+IP.1 = 127.0.0.1
+[ v3_ext ]
+authorityKeyIdentifier=keyid,issuer:always
+basicConstraints=CA:FALSE
+keyUsage=keyEncipherment,dataEncipherment,digitalSignature
+extendedKeyUsage=serverAuth,clientAuth
+subjectAltName=@alt_names"""
+    )
+
+    check_call(['openssl', 'genrsa', '-out', '/run/ca.key', '2048'])
+    check_call(['openssl', 'genrsa', '-out', '/run/server.key', '2048'])
+    check_call(
+        [
+            'openssl',
+            'req',
+            '-x509',
+            '-new',
+            '-sha256',
+            '-nodes',
+            '-days',
+            '3650',
+            '-key',
+            '/run/ca.key',
+            '-subj',
+            '/CN=127.0.0.1',
+            '-out',
+            '/run/ca.crt',
+        ]
+    )
+    check_call(
+        [
+            'openssl',
+            'req',
+            '-new',
+            '-sha256',
+            '-key',
+            '/run/server.key',
+            '-out',
+            '/run/server.csr',
+            '-config',
+            '/run/ssl.conf',
+        ]
+    )
+    check_call(
+        [
+            'openssl',
+            'x509',
+            '-req',
+            '-sha256',
+            '-in',
+            '/run/server.csr',
+            '-CA',
+            '/run/ca.crt',
+            '-CAkey',
+            '/run/ca.key',
+            '-CAcreateserial',
+            '-out',
+            '/run/cert.pem',
+            '-days',
+            '365',
+            '-extensions',
+            'v3_ext',
+            '-extfile',
+            '/run/ssl.conf',
+        ]
+    )
 
 
 class AdmissionWebhookCharm(CharmBase):
@@ -45,27 +140,10 @@ class AdmissionWebhookCharm(CharmBase):
             return
 
         model = os.environ['JUJU_MODEL_NAME']
-        run(
-            [
-                "openssl",
-                "req",
-                "-x509",
-                "-newkey",
-                "rsa:4096",
-                "-keyout",
-                "key.pem",
-                "-out",
-                "cert.pem",
-                "-days",
-                "365",
-                "-subj",
-                f"/CN={hookenv.service_name()}.{model}.svc",
-                "-nodes",
-            ],
-            check=True,
-        )
 
-        ca_bundle = b64encode(Path('cert.pem').read_bytes()).decode('utf-8')
+        gen_certs(model, hookenv.service_name())
+
+        ca_bundle = b64encode(Path('/run/cert.pem').read_bytes()).decode('utf-8')
 
         self.model.pod.set_spec(
             {
@@ -102,8 +180,14 @@ class AdmissionWebhookCharm(CharmBase):
                                 'name': 'certs',
                                 'mountPath': '/etc/webhook/certs',
                                 'files': [
-                                    {'path': 'cert.pem', 'content': Path('cert.pem').read_text()},
-                                    {'path': 'key.pem', 'content': Path('key.pem').read_text()},
+                                    {
+                                        'path': 'cert.pem',
+                                        'content': Path('/run/cert.pem').read_text(),
+                                    },
+                                    {
+                                        'path': 'key.pem',
+                                        'content': Path('/run/server.key').read_text(),
+                                    },
                                 ],
                             }
                         ],


### PR DESCRIPTION
Otherwise Kubernetes encounters a certificate error due to Go breaking backwards compatibility with Common Name certificates.

Fixes #308 