### PR TITLE
Restrict publishing job to relevant path changes

### DIFF
--- a/.github/workflows/publish-bundle.yaml
+++ b/.github/workflows/publish-bundle.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - charms/**
+      - bundle*.yaml
 
 jobs:
   all-bundles:


### PR DESCRIPTION
We shouldn't need to publish a new bundle for changes outside of `charms/` or the bundle YAML files.